### PR TITLE
Bootstrap repository structure with scaffolding files

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/issue.yml
+++ b/.github/ISSUE_TEMPLATE/issue.yml
@@ -1,0 +1,44 @@
+name: Issue
+description: Track work with explicit acceptance criteria.
+title: "[Issue]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form to capture the required issue details.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Short, single-paragraph summary.
+      placeholder: What is the change or problem?
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / Goal
+      description: What is broken or what outcome is needed?
+    validations:
+      required: true
+  - type: checkboxes
+    id: acceptance_obvious
+    attributes:
+      label: Acceptance criteria clarity
+      options:
+        - label: Criteria are obvious (docs-only or trivial change)
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria (if not obvious)
+      description: If criteria are obvious, write "Obvious" with a short note.
+      placeholder: List explicit criteria or success conditions.
+    validations:
+      required: true
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation / Evidence
+      description: How will completion be verified?
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+# Pull Request
+
+## Summary
+
+-
+
+## Issue Linkage
+
+- Fixes # (default; use when no acceptance criteria exist)
+- Ref # (use when acceptance criteria exist)
+- Work is not complete until the issue is closed.
+- If no issue exists, open one before any work begins.
+
+## Testing
+
+- markdownlint
+
+## Notes
+
+-

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# macOS
+.DS_Store
+
+# Editors
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Environments
+.env
+.envrc
+
+# Cursor
+.cursorignore
+.cursorindexingignore

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,4 @@
+{
+  "MD013": false,
+  "MD024": { "siblings_only": true }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# Agent Instructions
+
+<!-- include: docs/standards-and-conventions.md -->
+<!-- include: ./docs/repository-standards.md -->
+
+## User Overrides (Optional)
+
+If `~/AGENTS.md` exists and is readable, load it and apply it as a
+user-specific overlay for this session. If it cannot be read, say so
+briefly and continue.
+
+## Canonical Standards
+
+This repository follows the canonical standards and conventions in the
+`standards-and-conventions` repository.
+
+Resolve the local path (preferred):
+- `../standards-and-conventions`
+
+If the local path is unavailable, use the canonical web source:
+- https://github.com/wphillipmoore/standards-and-conventions
+
+If the canonical standards cannot be retrieved, treat it as a fatal
+exception and stop.
+
+## Shared Skills
+
+Replace `<standards-repo-path>` with the resolved local path when available.
+- Load all skills from: `<standards-repo-path>/skills/**/SKILL.md`
+- Treat every skill found under that directory as available and active.
+
+## Local Overrides
+
+None.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,166 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Documentation Strategy
+
+This repository uses two complementary approaches for AI agent guidance:
+
+- **AGENTS.md**: Generic AI agent instructions using include directives to force documentation indexing. Contains canonical standards references, shared skills loading, and user override support.
+- **CLAUDE.md** (this file): Claude Code-specific guidance with prescriptive commands, architecture details, and development workflows optimized for `/init`.
+
+### Integration Approach
+
+**For Claude Code** (`/init` command):
+1. Read CLAUDE.md (this file) first for optimized quick-start guidance
+2. Process include directives to load repository standards
+3. Reference AGENTS.md for shared skills and canonical standards location
+4. Apply layered standards: canonical → project-specific → user overrides
+
+**For other AI agents** (Codex, generic LLMs):
+1. Read AGENTS.md first as the primary entry point
+2. Process include directives to load all referenced documentation
+3. Resolve canonical standards repo path (local or GitHub)
+4. Load shared skills from standards repo
+5. Apply user overrides from `~/AGENTS.md` if present
+
+**Key differences**:
+- **CLAUDE.md**: Prescriptive, command-focused, optimized for `/init`
+- **AGENTS.md**: Declarative, include-directive-driven, forces full documentation indexing
+
+Both files share the same underlying standards via include directives, ensuring consistency across all AI agents working in this repository.
+
+### Best Practices for Dual-File Approach
+
+**What goes in AGENTS.md**:
+- Include directives for documentation indexing
+- Canonical standards repository references
+- Shared skills loading instructions
+- User override mechanisms
+- Minimal, declarative content
+
+**What goes in CLAUDE.md**:
+- Claude Code-specific quick-start commands
+- Detailed architecture and design patterns
+- Implementation notes and common workflows
+- Integration guidance between the two files
+- More verbose, prescriptive content
+
+**What goes in neither (use includes instead)**:
+- Repository standards (keep in `docs/repository-standards.md`)
+- Canonical standards (reference external repo)
+- Project-specific conventions (keep in referenced docs)
+
+**Maintenance strategy**:
+- Update standards in source files, not in AGENTS.md or CLAUDE.md
+- Use include directives to pull in shared content
+- Keep AGENTS.md minimal and CLAUDE.md focused on Claude Code workflows
+- Test both entry points when updating documentation structure
+
+<!-- include: docs/standards-and-conventions.md -->
+<!-- include: docs/repository-standards.md -->
+
+## Project Overview
+
+This is the shared common repository for the mq-rest-admin project family, serving two roles:
+
+1. **Documentation fragments**: Language-neutral documentation fragments consumed by the per-language repos (Java, Python, Go) via their documentation toolchains
+2. **Canonical mapping data**: Single source of truth for `mapping-data.json`, the MQ REST API attribute mapping definitions consumed by all language implementations
+
+**Project name**: mq-rest-admin-common
+
+**Status**: Active
+
+**Canonical Standards**: This repository follows standards at https://github.com/wphillipmoore/standards-and-conventions (local path: `../standards-and-conventions` if available)
+
+## Development Commands
+
+This is a documentation-only repository. There are no build or test commands.
+
+### Validation
+
+```bash
+markdownlint '**/*.md'    # Lint all Markdown files
+```
+
+## Architecture
+
+### Fragment Organization
+
+```text
+fragments/
+  architecture/           # Core architecture concepts
+  mapping-pipeline/       # Attribute mapping pipeline
+  design/                 # Design decisions and rationale
+  concepts/               # High-level patterns (ensure, sync)
+```
+
+Fragments contain language-neutral concept explanations, diagrams, and tables.
+They do NOT contain language-specific code examples, documentation tool syntax,
+or references to specific library names.
+
+### mapping-data.json
+
+The root-level `mapping-data.json` is the canonical source for MQ REST API
+attribute mapping definitions. It contains:
+
+- **commands**: MQSC command → qualifier mapping (e.g., `"ALTER CHANNEL"` → `"channel"`)
+- **qualifiers**: Per-qualifier mapping tables with four map types:
+  - `request_key_map`: Friendly name → MQSC parameter (outbound)
+  - `request_value_map`: Friendly value → MQSC value (outbound)
+  - `response_key_map`: MQSC parameter → friendly name (inbound)
+  - `response_value_map`: MQSC value → friendly value (inbound)
+  - `request_key_value_map`: Composite key-value transforms (e.g., replace/noreplace)
+  - `response_parameter_macros`: Parameter groups expanded at runtime
+- **version**: Schema version (currently `1`)
+
+### How Consuming Repos Integrate
+
+- **Java**: Copies `mapping-data.json` into `src/main/resources/` (via CI or manual sync)
+- **Python**: References via local clone or CI checkout
+- **Go**: Uses `go:embed` or symlink from local clone
+- **Documentation sites**: Each language repo clones this repository and uses its
+  documentation tool's include mechanism (`pymdownx.snippets`, MyST `{include}`)
+
+## Documentation Indexing Strategy
+
+This repository uses `<!-- include: path/to/file.md -->` directives to force documentation indexing. When you encounter these directives:
+
+1. **Read the referenced files** to understand the full context
+2. **Apply layered standards** in order:
+   - Canonical standards (from `standards-and-conventions` repo)
+   - Project-specific standards (`docs/repository-standards.md`)
+   - User overrides (`~/AGENTS.md` if present)
+3. **Load shared skills** from `<standards-repo-path>/skills/**/SKILL.md`
+
+The include directives appear in:
+- `AGENTS.md` - Includes repository standards and conventions
+- `CLAUDE.md` - Includes same standards for Claude Code
+- `docs/standards-and-conventions.md` - Includes canonical standards reference
+
+This approach ensures all AI agents (Codex, Claude, etc.) have access to the same foundational documentation.
+
+## Documentation Structure
+
+- `README.md` - Project overview and quick start
+- `AGENTS.md` - Generic AI agent instructions with include directives
+- `CLAUDE.md` - This file, Claude Code-specific guidance
+- `docs/repository-standards.md` - Project-specific standards (included from AGENTS.md)
+- `docs/standards-and-conventions.md` - Canonical standards reference (includes external repo)
+
+## Key References
+
+**Canonical Standards**: https://github.com/wphillipmoore/standards-and-conventions
+- Local path (preferred): `../standards-and-conventions`
+- Load all skills from: `<standards-repo-path>/skills/**/SKILL.md`
+
+**Sibling repositories**:
+- `../mq-rest-admin-python` — Python implementation
+- `../mq-rest-admin-java` — Java implementation
+- `../mq-rest-admin-go` — Go implementation
+
+**External Documentation**:
+- IBM MQ 9.4 administrative REST API
+- MQSC command reference
+
+**User Overrides**: `~/AGENTS.md` (optional, applied if present and readable)

--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -1,0 +1,43 @@
+# Repository Standards
+
+## Table of Contents
+
+- [Pre-flight checklist](#pre-flight-checklist)
+- [AI co-authors](#ai-co-authors)
+- [Repository profile](#repository-profile)
+- [Local validation](#local-validation)
+- [Merge strategy override](#merge-strategy-override)
+
+## Pre-flight checklist
+
+- Before modifying any files, check the current branch with `git status -sb`.
+- If on `develop`, create a short-lived `feature/*` branch or ask for explicit approval to proceed on `develop`.
+- If approval is granted to work on `develop`, call it out in the response and proceed only for that user-approved scope.
+
+## AI co-authors
+
+- Co-Authored-By: wphillipmoore-codex <255923655+wphillipmoore-codex@users.noreply.github.com>
+- Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>
+
+## Repository profile
+
+- repository_type: documentation
+- versioning_scheme: library
+- branching_model: library-release
+- release_model: artifact-publishing
+- supported_release_lines: current and previous
+
+## Local validation
+
+```bash
+markdownlint '**/*.md'    # Lint all Markdown files
+```
+
+## Merge strategy override
+
+- Feature, bugfix, and chore PRs targeting `develop` use squash merges (`--squash`).
+- Release PRs targeting `main` use regular merges (`--merge`) to preserve shared
+  ancestry between `main` and `develop`.
+- Auto-merge commands:
+  - Feature PRs: `gh pr merge --auto --squash --delete-branch`
+  - Release PRs: `gh pr merge --auto --merge --delete-branch`

--- a/docs/standards-and-conventions.md
+++ b/docs/standards-and-conventions.md
@@ -1,0 +1,17 @@
+# Standards and Conventions
+
+This repository follows the canonical standards at:
+<https://github.com/wphillipmoore/standards-and-conventions>
+
+## Table of Contents
+
+- [Canonical references](#canonical-references)
+- [Project-specific overlay](#project-specific-overlay)
+
+## Canonical references
+<!-- include: ../standards-and-conventions/docs/standards-and-conventions.md -->
+
+## Project-specific overlay
+
+Project-specific content lives in `docs/repository-standards.md` and is
+included from `AGENTS.md` only.

--- a/mapping-data.json
+++ b/mapping-data.json
@@ -1,0 +1,2560 @@
+{
+  "commands": {
+    "ALTER AUTHINFO": {
+      "qualifier": "authinfo"
+    },
+    "ALTER BUFFPOOL": {
+      "qualifier": "buffpool"
+    },
+    "ALTER CFSTRUCT": {
+      "qualifier": "cfstruct"
+    },
+    "ALTER CHANNEL": {
+      "qualifier": "channel"
+    },
+    "ALTER COMMINFO": {
+      "qualifier": "comminfo"
+    },
+    "ALTER LISTENER": {
+      "qualifier": "listener"
+    },
+    "ALTER NAMELIST": {
+      "qualifier": "namelist"
+    },
+    "ALTER PROCESS": {
+      "qualifier": "process"
+    },
+    "ALTER PSID": {
+      "qualifier": "psid"
+    },
+    "ALTER QMGR": {
+      "qualifier": "qmgr"
+    },
+    "ALTER SECURITY": {
+      "qualifier": "security"
+    },
+    "ALTER SERVICE": {
+      "qualifier": "service"
+    },
+    "ALTER SMDS": {
+      "qualifier": "smds"
+    },
+    "ALTER STGCLASS": {
+      "qualifier": "stgclass"
+    },
+    "ALTER SUB": {
+      "qualifier": "sub"
+    },
+    "ALTER TOPIC": {
+      "qualifier": "topic"
+    },
+    "ALTER TRACE": {
+      "qualifier": "trace"
+    },
+    "ARCHIVE LOG": {
+      "qualifier": "log"
+    },
+    "BACKUP CFSTRUCT": {
+      "qualifier": "cfstruct"
+    },
+    "CLEAR QLOCAL": {
+      "qualifier": "queue"
+    },
+    "CLEAR TOPICSTR": {
+      "qualifier": "topicstr"
+    },
+    "DEFINE AUTHINFO": {
+      "qualifier": "authinfo"
+    },
+    "DEFINE BUFFPOOL": {
+      "qualifier": "buffpool"
+    },
+    "DEFINE CFSTRUCT": {
+      "qualifier": "cfstruct"
+    },
+    "DEFINE CHANNEL": {
+      "qualifier": "channel"
+    },
+    "DEFINE COMMINFO": {
+      "qualifier": "comminfo"
+    },
+    "DEFINE LISTENER": {
+      "qualifier": "listener"
+    },
+    "DEFINE LOG": {
+      "qualifier": "log"
+    },
+    "DEFINE MAXSMSGS": {
+      "qualifier": "maxsmsgs"
+    },
+    "DEFINE NAMELIST": {
+      "qualifier": "namelist"
+    },
+    "DEFINE PROCESS": {
+      "qualifier": "process"
+    },
+    "DEFINE PSID": {
+      "qualifier": "psid"
+    },
+    "DEFINE SERVICE": {
+      "qualifier": "service"
+    },
+    "DEFINE STGCLASS": {
+      "qualifier": "stgclass"
+    },
+    "DEFINE SUB": {
+      "qualifier": "sub"
+    },
+    "DEFINE TOPIC": {
+      "qualifier": "topic"
+    },
+    "DELETE AUTHINFO": {
+      "qualifier": "authinfo"
+    },
+    "DELETE AUTHREC": {
+      "qualifier": "authrec"
+    },
+    "DELETE BUFFPOOL": {
+      "qualifier": "buffpool"
+    },
+    "DELETE CFSTRUCT": {
+      "qualifier": "cfstruct"
+    },
+    "DELETE CHANNEL": {
+      "qualifier": "channel"
+    },
+    "DELETE COMMINFO": {
+      "qualifier": "comminfo"
+    },
+    "DELETE LISTENER": {
+      "qualifier": "listener"
+    },
+    "DELETE NAMELIST": {
+      "qualifier": "namelist"
+    },
+    "DELETE POLICY": {
+      "qualifier": "policy"
+    },
+    "DELETE PROCESS": {
+      "qualifier": "process"
+    },
+    "DELETE PSID": {
+      "qualifier": "psid"
+    },
+    "DELETE SERVICE": {
+      "qualifier": "service"
+    },
+    "DELETE STGCLASS": {
+      "qualifier": "stgclass"
+    },
+    "DELETE SUB": {
+      "qualifier": "sub"
+    },
+    "DELETE QALIAS": {
+      "qualifier": "queue"
+    },
+    "DELETE QLOCAL": {
+      "qualifier": "queue"
+    },
+    "DELETE QMODEL": {
+      "qualifier": "queue"
+    },
+    "DELETE QREMOTE": {
+      "qualifier": "queue"
+    },
+    "DELETE TOPIC": {
+      "qualifier": "topic"
+    },
+    "DISPLAY APSTATUS": {
+      "qualifier": "apstatus"
+    },
+    "DISPLAY ARCHIVE": {
+      "qualifier": "archive"
+    },
+    "DISPLAY AUTHINFO": {
+      "qualifier": "authinfo"
+    },
+    "DISPLAY AUTHREC": {
+      "qualifier": "authrec",
+      "response_parameter_macros": [
+        "AUTHLIST",
+        "ENTITY",
+        "ENTTYPE"
+      ]
+    },
+    "DISPLAY AUTHSERV": {
+      "qualifier": "authserv"
+    },
+    "DISPLAY CFSTATUS": {
+      "qualifier": "cfstatus"
+    },
+    "DISPLAY CFSTRUCT": {
+      "qualifier": "cfstruct"
+    },
+    "DISPLAY CHANNEL": {
+      "qualifier": "channel"
+    },
+    "DISPLAY CHINIT": {
+      "qualifier": "chinit"
+    },
+    "DISPLAY CHLAUTH": {
+      "qualifier": "chlauth"
+    },
+    "DISPLAY CHSTATUS": {
+      "qualifier": "chstatus"
+    },
+    "DISPLAY CLUSQMGR": {
+      "qualifier": "clusqmgr"
+    },
+    "DISPLAY CMDSERV": {
+      "qualifier": "cmdserv"
+    },
+    "DISPLAY COMMINFO": {
+      "qualifier": "comminfo"
+    },
+    "DISPLAY CONN": {
+      "qualifier": "conn"
+    },
+    "DISPLAY ENTAUTH": {
+      "qualifier": "entauth",
+      "response_parameter_macros": [
+        "AUTHLIST",
+        "ENTITY",
+        "ENTTYPE",
+        "OBJTYPE"
+      ]
+    },
+    "DISPLAY GROUP": {
+      "qualifier": "group"
+    },
+    "DISPLAY LISTENER": {
+      "qualifier": "listener"
+    },
+    "DISPLAY LOG": {
+      "qualifier": "log"
+    },
+    "DISPLAY LSSTATUS": {
+      "qualifier": "lsstatus"
+    },
+    "DISPLAY MAXSMSGS": {
+      "qualifier": "maxsmsgs"
+    },
+    "DISPLAY NAMELIST": {
+      "qualifier": "namelist"
+    },
+    "DISPLAY POLICY": {
+      "qualifier": "policy"
+    },
+    "DISPLAY PROCESS": {
+      "qualifier": "process"
+    },
+    "DISPLAY PUBSUB": {
+      "qualifier": "pubsub"
+    },
+    "DISPLAY QMGR": {
+      "qualifier": "qmgr",
+      "response_parameter_macros": [
+        "CHINIT",
+        "CLUSTER",
+        "EVENT",
+        "PUBSUB",
+        "SYSTEM"
+      ]
+    },
+    "DISPLAY QMSTATUS": {
+      "qualifier": "qmstatus",
+      "response_parameter_macros": [
+        "LOG"
+      ]
+    },
+    "DISPLAY QSTATUS": {
+      "qualifier": "qstatus",
+      "response_parameter_macros": [
+        "MONITOR"
+      ]
+    },
+    "DISPLAY QUEUE": {
+      "qualifier": "queue",
+      "response_parameter_macros": [
+        "CLUSINFO"
+      ]
+    },
+    "DISPLAY SBSTATUS": {
+      "qualifier": "sbstatus"
+    },
+    "DISPLAY SECURITY": {
+      "qualifier": "security"
+    },
+    "DISPLAY SERVICE": {
+      "qualifier": "service"
+    },
+    "DISPLAY SMDS": {
+      "qualifier": "smds"
+    },
+    "DISPLAY SMDSCONN": {
+      "qualifier": "smdsconn"
+    },
+    "DISPLAY STGCLASS": {
+      "qualifier": "stgclass"
+    },
+    "DISPLAY SUB": {
+      "qualifier": "sub",
+      "response_parameter_macros": [
+        "SUMMARY"
+      ]
+    },
+    "DISPLAY SYSTEM": {
+      "qualifier": "system"
+    },
+    "DISPLAY SVSTATUS": {
+      "qualifier": "svstatus"
+    },
+    "DISPLAY TCLUSTER": {
+      "qualifier": "tcluster"
+    },
+    "DISPLAY THREAD": {
+      "qualifier": "thread"
+    },
+    "DISPLAY TOPIC": {
+      "qualifier": "topic"
+    },
+    "DISPLAY TPSTATUS": {
+      "qualifier": "tpstatus"
+    },
+    "DISPLAY TRACE": {
+      "qualifier": "trace"
+    },
+    "DISPLAY USAGE": {
+      "qualifier": "usage"
+    },
+    "MOVE QLOCAL": {
+      "qualifier": "queue"
+    },
+    "PING CHANNEL": {
+      "qualifier": "channel"
+    },
+    "PING QMGR": {
+      "qualifier": "qmgr"
+    },
+    "PURGE CHANNEL": {
+      "qualifier": "channel"
+    },
+    "RECOVER BSDS": {
+      "qualifier": "bsds"
+    },
+    "RECOVER CFSTRUCT": {
+      "qualifier": "cfstruct"
+    },
+    "REFRESH CLUSTER": {
+      "qualifier": "cluster"
+    },
+    "REFRESH QMGR": {
+      "qualifier": "qmgr"
+    },
+    "REFRESH SECURITY": {
+      "qualifier": "security"
+    },
+    "RESET CFSTRUCT": {
+      "qualifier": "cfstruct"
+    },
+    "RESET CHANNEL": {
+      "qualifier": "channel"
+    },
+    "RESET CLUSTER": {
+      "qualifier": "cluster"
+    },
+    "RESET QMGR": {
+      "qualifier": "qmgr"
+    },
+    "RESET QSTATS": {
+      "qualifier": "queue"
+    },
+    "RESET SMDS": {
+      "qualifier": "smds"
+    },
+    "RESET TPIPE": {
+      "qualifier": "tpipe"
+    },
+    "RESOLVE CHANNEL": {
+      "qualifier": "channel"
+    },
+    "RESOLVE INDOUBT": {
+      "qualifier": "indoubt"
+    },
+    "RESUME QMGR": {
+      "qualifier": "qmgr"
+    },
+    "RVERIFY SECURITY": {
+      "qualifier": "security"
+    },
+    "SET ARCHIVE": {
+      "qualifier": "archive"
+    },
+    "SET AUTHREC": {
+      "qualifier": "authrec"
+    },
+    "SET CHLAUTH": {
+      "qualifier": "chlauth"
+    },
+    "SET LOG": {
+      "qualifier": "log"
+    },
+    "SET POLICY": {
+      "qualifier": "policy"
+    },
+    "SET SYSTEM": {
+      "qualifier": "system"
+    },
+    "START CHANNEL": {
+      "qualifier": "channel"
+    },
+    "START CHINIT": {
+      "qualifier": "chinit"
+    },
+    "START CMDSERV": {
+      "qualifier": "cmdserv"
+    },
+    "START LISTENER": {
+      "qualifier": "listener"
+    },
+    "START QMGR": {
+      "qualifier": "qmgr"
+    },
+    "START SERVICE": {
+      "qualifier": "service"
+    },
+    "START SMDSCONN": {
+      "qualifier": "smdsconn"
+    },
+    "START TRACE": {
+      "qualifier": "trace"
+    },
+    "STOP CHANNEL": {
+      "qualifier": "channel"
+    },
+    "STOP CHINIT": {
+      "qualifier": "chinit"
+    },
+    "STOP CMDSERV": {
+      "qualifier": "cmdserv"
+    },
+    "STOP CONN": {
+      "qualifier": "conn"
+    },
+    "STOP LISTENER": {
+      "qualifier": "listener"
+    },
+    "STOP QMGR": {
+      "qualifier": "qmgr"
+    },
+    "STOP SERVICE": {
+      "qualifier": "service"
+    },
+    "STOP SMDSCONN": {
+      "qualifier": "smdsconn"
+    },
+    "STOP TRACE": {
+      "qualifier": "trace"
+    },
+    "SUSPEND QMGR": {
+      "qualifier": "qmgr"
+    }
+  },
+  "qualifiers": {
+    "apstatus": {
+      "request_key_map": {},
+      "request_value_map": {},
+      "response_key_map": {
+        "ACTIVE": "queue_manager_active",
+        "BALANCED": "balanced",
+        "BALOPTS": "balancing_options",
+        "BALSTATE": "balance_state",
+        "BALTMOUT": "timeout",
+        "BALTYPE": "application_type",
+        "CLUSTER": "cluster_name",
+        "CONNS": "connections",
+        "CONNTAG": "connection_tag",
+        "COUNT": "instance_count",
+        "IMMCOUNT": "immovable_count",
+        "IMMDATE": "immovable_date",
+        "IMMREASN": "immovable_reason",
+        "IMMTIME": "immovable_time",
+        "LMSGDATE": "last_message_date",
+        "LMSGTIME": "last_message_time",
+        "MOVABLE": "movable",
+        "MOVCOUNT": "movable_instance_count",
+        "QMID": "queue_manager_id",
+        "QMNAME": "queue_manager_name"
+      },
+      "response_value_map": {}
+    },
+    "archive": {
+      "request_key_map": {
+        "allocation_primary": "PRIQTY",
+        "allocation_secondary": "SECQTY",
+        "allocation_units": "ALCUNIT",
+        "archive_prefix1": "ARCPFX1",
+        "archive_prefix2": "ARCPFX2",
+        "archive_retention": "ARCRETN",
+        "archive_unit2": "UNIT2",
+        "archive_wait_for_reply": "ARCWTOR",
+        "block_size": "BLKSIZE",
+        "catalog": "CATALOG",
+        "command_scope": "CMDSCOPE",
+        "compact": "COMPACT",
+        "protect": "PROTECT",
+        "quiesce_interval": "QUIESCE",
+        "archive_routing_code": "ARCWRTC",
+        "time_stamp_format": "TSTAMP"
+      },
+      "request_value_map": {},
+      "response_key_map": {},
+      "response_value_map": {}
+    },
+    "authinfo": {
+      "request_key_map": {
+        "adopt_context": "ADOPTCTX",
+        "authentication_info_type": "AUTHTYPE",
+        "authentication_method": "AUTHENMD",
+        "authorization_method": "AUTHORMD",
+        "base_dn_group": "BASEDNG",
+        "base_dn_user": "BASEDNU",
+        "check_client": "CHCKCLNT",
+        "check_local": "CHCKLOCL",
+        "class_group": "CLASSGRP",
+        "class_user": "CLASSUSR",
+        "command_scope": "CMDSCOPE",
+        "connection_name": "CONNAME",
+        "description": "DESCR",
+        "failure_delay": "FAILDLAY",
+        "find_group": "FINDGRP",
+        "group_field": "GRPFIELD",
+        "group_nesting": "NESTGRP",
+        "ignore_state": "IGNSTATE",
+        "ldap_password": "LDAPPWD",
+        "ldap_user_name": "LDAPUSER",
+        "like": "LIKE",
+        "ocsp_responder_url": "OCSPURL",
+        "queue_sharing_group_disposition": "QSGDISP",
+        "secure_communications": "SECCOMM",
+        "short_user": "SHORTUSR",
+        "user_field": "USRFIELD"
+      },
+      "request_key_value_map": {
+        "noreplace": {
+          "yes": {
+            "key": "REPLACE",
+            "value": "NO"
+          }
+        },
+        "replace": {
+          "no": {
+            "key": "REPLACE",
+            "value": "NO"
+          },
+          "yes": {
+            "key": "REPLACE",
+            "value": "YES"
+          }
+        }
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "ADOPTCTX": "adopt_context",
+        "ALTDATE": "alteration_date",
+        "ALTTIME": "alteration_time",
+        "AUTHENMD": "authentication_method",
+        "AUTHORMD": "authorization_method",
+        "AUTHTYPE": "authentication_info_type",
+        "BASEDNG": "base_dn_group",
+        "BASEDNU": "base_dn_user",
+        "CHCKCLNT": "check_client",
+        "CHCKLOCL": "check_local",
+        "CLASSGRP": "class_group",
+        "CLASSUSR": "class_user",
+        "CONNAME": "connection_name",
+        "DESCR": "description",
+        "FAILDLAY": "failure_delay",
+        "FINDGRP": "find_group",
+        "GRPFIELD": "group_field",
+        "LDAPPWD": "ldap_password",
+        "LDAPUSER": "ldap_user_name",
+        "NESTGRP": "group_nesting",
+        "OCSPURL": "ocsp_responder_url",
+        "QSGDISP": "queue_sharing_group_disposition",
+        "SECCOMM": "secure_communications",
+        "SHORTUSR": "short_user",
+        "USRFIELD": "user_field"
+      },
+      "response_value_map": {}
+    },
+    "authrec": {
+      "request_key_map": {
+        "authority_add": "AUTHADD",
+        "authority_remove": "AUTHRMV",
+        "group_names": "GROUP",
+        "ignore_state": "IGNSTATE",
+        "object_type": "OBJTYPE",
+        "options": "MATCH",
+        "principal_names": "PRINCIPAL",
+        "profile_name": "PROFILE",
+        "service_component": "SERVCOMP"
+      },
+      "request_value_map": {},
+      "response_key_map": {},
+      "response_value_map": {}
+    },
+    "authserv": {
+      "request_key_map": {},
+      "request_value_map": {},
+      "response_key_map": {
+        "IFVER": "interface_version",
+        "UIDSUPP": "user_id_support"
+      },
+      "response_value_map": {}
+    },
+    "bsds": {
+      "request_key_map": {},
+      "request_value_map": {},
+      "response_key_map": {},
+      "response_value_map": {}
+    },
+    "buffpool": {
+      "request_key_map": {},
+      "request_value_map": {},
+      "response_key_map": {},
+      "response_value_map": {}
+    },
+    "cfstatus": {
+      "request_key_map": {
+        "shared_message_dataset": "SMDS"
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "ACCESS": "access",
+        "BKUPDATE": "backup_date",
+        "BKUPERBA": "backup_end_rba",
+        "BKUPSIZE": "backup_size",
+        "BKUPSRBA": "backup_start_rba",
+        "BKUPTIME": "backup_time",
+        "CFTYPE": "cf_struct_type",
+        "ENTSMAX": "entries_max",
+        "ENTSUSED": "entries_used",
+        "FAILDATE": "fail_date",
+        "FAILTIME": "fail_time",
+        "LOGS": "log_queue_manager_names",
+        "OFFLDUSE": "offload_use",
+        "QMNAME": "queue_manager_name",
+        "RCVDATE": "recovery_start_date",
+        "RCVTIME": "recovery_start_time",
+        "SIZEMAX": "size_max",
+        "SIZEUSED": "size_used",
+        "SMDS": "shared_message_dataset",
+        "STATUS": "cf_status_type",
+        "SYSNAME": "system_name"
+      },
+      "response_value_map": {}
+    },
+    "cfstruct": {
+      "request_key_map": {
+        "action": "ACTION",
+        "cf_connection_lost": "CFCONLOS",
+        "cf_level": "CFLEVEL",
+        "command_scope": "CMDSCOPE",
+        "data_sharing_block": "DSBLOCK",
+        "data_sharing_buffers": "DSBUFS",
+        "data_sharing_expand": "DSEXPAND",
+        "data_sharing_group": "DSGROUP",
+        "description": "DESCR",
+        "exclude_interval": "EXCLINT",
+        "like": "LIKE",
+        "offload": "OFFLOAD",
+        "offload_size1": "OFFLD1SZ",
+        "offload_size2": "OFFLD2SZ",
+        "offload_size3": "OFFLD3SZ",
+        "offload_threshold1": "OFFLD1TH",
+        "offload_threshold2": "OFFLD2TH",
+        "offload_threshold3": "OFFLD3TH",
+        "purge": "TYPE",
+        "recovery_auto": "RECAUTO",
+        "recovery": "RECOVER"
+      },
+      "request_key_value_map": {
+        "noreplace": {
+          "yes": {
+            "key": "REPLACE",
+            "value": "NO"
+          }
+        },
+        "replace": {
+          "no": {
+            "key": "REPLACE",
+            "value": "NO"
+          },
+          "yes": {
+            "key": "REPLACE",
+            "value": "YES"
+          }
+        }
+      },
+      "request_value_map": {
+        "purge": {
+          "no": "NORMAL",
+          "yes": "PURGE"
+        }
+      },
+      "response_key_map": {
+        "ALTDATE": "alteration_date",
+        "ALTTIME": "alteration_time",
+        "CFCONLOS": "cf_connection_lost",
+        "CFLEVEL": "cf_level",
+        "DESCR": "description",
+        "DSBLOCK": "data_sharing_block",
+        "DSBUFS": "data_sharing_buffers",
+        "DSEXPAND": "data_sharing_expand",
+        "DSGROUP": "data_sharing_group",
+        "OFFLD1SZ": "offload_size1",
+        "OFFLD1TH": "offload_threshold1",
+        "OFFLD2SZ": "offload_size2",
+        "OFFLD2TH": "offload_threshold2",
+        "OFFLD3SZ": "offload_size3",
+        "OFFLD3TH": "offload_threshold3",
+        "OFFLOAD": "offload",
+        "RECAUTO": "recovery_auto",
+        "RECOVER": "recovery"
+      },
+      "response_value_map": {}
+    },
+    "channel": {
+      "request_key_map": {
+        "amqp_keep_alive": "AMQPKA",
+        "backlog": "BACKLOG",
+        "batch_data_limit": "BATCHLIM",
+        "batch_heartbeat": "BATCHHB",
+        "batch_interval": "BATCHINT",
+        "batch_size": "BATCHSZ",
+        "certificate_label": "CERTLABL",
+        "channel_disposition": "CHLDISP",
+        "channel_monitoring": "MONCHL",
+        "channel_statistics": "STATCHL",
+        "channel_status": "STATUS",
+        "channel_table": "CHLTABLE",
+        "channel_type": "CHLTYPE",
+        "client_channel_weight": "CLNTWGHT",
+        "client_id": "CLIENTID",
+        "cluster_name": "CLUSTER",
+        "cluster_namelist": "CLUSNL",
+        "cluster_workload_channel_weight": "CLWLWGHT",
+        "cluster_workload_priority": "CLWLPRTY",
+        "cluster_workload_rank": "CLWLRANK",
+        "command_scope": "CMDSCOPE",
+        "connection_affinity": "AFFINITY",
+        "connection_name": "CONNAME",
+        "data_conversion": "CONVERT",
+        "data_count": "DATALEN",
+        "default_reconnect": "DEFRECON",
+        "default_channel_disposition": "DEFCDISP",
+        "description": "DESCR",
+        "disconnect_interval": "DISCINT",
+        "header_compression": "COMPHDR",
+        "heartbeat_interval": "HBINT",
+        "ignore_state": "IGNSTATE",
+        "in_doubt": "ACTION",
+        "jaas_config": "JAASCFG",
+        "keep_alive_interval": "KAINT",
+        "like": "LIKE",
+        "local_address": "LOCLADDR",
+        "long_retry_count": "LONGRTY",
+        "long_retry_interval": "LONGTMR",
+        "max_instances": "MAXINST",
+        "max_instances_per_client": "MAXINSTC",
+        "max_message_length": "MAXMSGL",
+        "mca_name": "MCANAME",
+        "mca_type": "MCATYPE",
+        "mca_user": "MCAUSER",
+        "message_compression": "COMPMSG",
+        "message_exit": "MSGEXIT",
+        "message_retry_count": "MRRTY",
+        "message_retry_exit": "MREXIT",
+        "message_retry_interval": "MRTMR",
+        "message_retry_user_data": "MRDATA",
+        "message_sequence_number": "SEQNUM",
+        "message_user_data": "MSGDATA",
+        "mode": "MODE",
+        "mode_name": "MODENAME",
+        "network_priority": "NETPRTY",
+        "non_persistent_message_speed": "NPMSPEED",
+        "password": "PASSWORD",
+        "port": "PORT",
+        "property_control": "PROPCTL",
+        "protocol": "PROTOCOL",
+        "put_authority": "PUTAUT",
+        "queue_manager_name": "QMNAME",
+        "queue_sharing_group_disposition": "QSGDISP",
+        "receive_exit": "RCVEXIT",
+        "receive_user_data": "RCVDATA",
+        "security_exit": "SCYEXIT",
+        "security_user_data": "SCYDATA",
+        "send_exit": "SENDEXIT",
+        "send_user_data": "SENDDATA",
+        "sequence_number_wrap": "SEQWRAP",
+        "sharing_conversations": "SHARECNV",
+        "short_retry_count": "SHORTRTY",
+        "short_retry_interval": "SHORTTMR",
+        "security_policy_protection": "SPLPROT",
+        "ssl_cipher_spec": "SSLCIPH",
+        "ssl_client_authentication": "SSLCAUTH",
+        "ssl_key_repository": "SSLKEYR",
+        "ssl_pass_phrase": "SSLKEYP",
+        "ssl_peer_name": "SSLPEER",
+        "temporary_model_queue_name": "TMPMODEL",
+        "temporary_queue_prefix": "TMPQPRFX",
+        "topic_root": "TPROOT",
+        "transaction_program_name": "TPNAME",
+        "transmission_queue_name": "XMITQ",
+        "transport_type": "TRPTYPE",
+        "use_client_id": "USECLTID",
+        "use_dead_letter_queue": "USEDLQ",
+        "user_id": "USERID"
+      },
+      "request_key_value_map": {
+        "channel_instance_type": {
+          "current": {
+            "key": "CURRENT",
+            "value": "YES"
+          },
+          "saved": {
+            "key": "SAVED",
+            "value": "YES"
+          },
+          "short": {
+            "key": "SHORT",
+            "value": "YES"
+          }
+        },
+        "noreplace": {
+          "yes": {
+            "key": "REPLACE",
+            "value": "NO"
+          }
+        },
+        "replace": {
+          "no": {
+            "key": "REPLACE",
+            "value": "NO"
+          },
+          "yes": {
+            "key": "REPLACE",
+            "value": "YES"
+          }
+        }
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "AFFINITY": "connection_affinity",
+        "ALTDATE": "alteration_date",
+        "ALTTIME": "alteration_time",
+        "AMQPKA": "amqp_keep_alive",
+        "AUTOSTART": "auto_start",
+        "BATCHHB": "batch_heartbeat",
+        "BATCHINT": "batch_interval",
+        "BATCHLIM": "batch_data_limit",
+        "BATCHSZ": "batch_size",
+        "CERTLABL": "certificate_label",
+        "CHLTYPE": "channel_type",
+        "CLNTWGHT": "client_channel_weight",
+        "CLUSNL": "cluster_namelist",
+        "CLUSTER": "cluster_name",
+        "CLWLPRTY": "cluster_workload_priority",
+        "CLWLRANK": "cluster_workload_rank",
+        "CLWLWGHT": "cluster_workload_channel_weight",
+        "COMPHDR": "header_compression",
+        "COMPMSG": "message_compression",
+        "CONNAME": "connection_name",
+        "CONVERT": "data_conversion",
+        "DEFCDISP": "default_channel_disposition",
+        "DESCR": "description",
+        "DISCINT": "disconnect_interval",
+        "HBINT": "heartbeat_interval",
+        "KAINT": "keep_alive_interval",
+        "LOCLADDR": "local_address",
+        "LONGRTY": "long_retry_count",
+        "LONGTMR": "long_retry_interval",
+        "MAXINST": "max_instances",
+        "MAXINSTC": "max_instances_per_client",
+        "MAXMSGL": "max_message_length",
+        "MCANAME": "mca_name",
+        "MCATYPE": "mca_type",
+        "MCAUSER": "mca_user",
+        "MODENAME": "mode_name",
+        "MONCHL": "channel_monitoring",
+        "MRDATA": "message_retry_user_data",
+        "MREXIT": "message_retry_exit",
+        "MRRTY": "message_retry_count",
+        "MRTMR": "message_retry_interval",
+        "MSGDATA": "message_user_data",
+        "MSGEXIT": "message_exit",
+        "NETPRTY": "network_priority",
+        "NPMSPEED": "non_persistent_message_speed",
+        "PASSWORD": "password",
+        "PORT": "port",
+        "PROPCTL": "property_control",
+        "PUTAUT": "put_authority",
+        "QMNAME": "queue_manager_name",
+        "RCVDATA": "receive_user_data",
+        "RCVEXIT": "receive_exit",
+        "RESETSEQ": "reset_sequence",
+        "SCYDATA": "security_user_data",
+        "SCYEXIT": "security_exit",
+        "SENDDATA": "send_user_data",
+        "SENDEXIT": "send_exit",
+        "SEQWRAP": "sequence_number_wrap",
+        "SHARECNV": "sharing_conversations",
+        "SHORTRTY": "short_retry_count",
+        "SHORTTMR": "short_retry_interval",
+        "SPLPROT": "security_policy_protection",
+        "SSLCAUTH": "ssl_client_authentication",
+        "SSLCIPH": "ssl_cipher_spec",
+        "SSLPEER": "ssl_peer_name",
+        "STATCHL": "channel_statistics",
+        "TPNAME": "transaction_program_name",
+        "TPROOT": "topic_root",
+        "CHANNEL": "channel_name",
+        "DEFRECON": "default_reconnect",
+        "TMPMODEL": "temporary_model_queue_name",
+        "TMPQPRFX": "temporary_queue_prefix",
+        "TRPTYPE": "transport_type",
+        "USECLTID": "use_client_id",
+        "USEDLQ": "use_dead_letter_queue",
+        "USERID": "user_id",
+        "XMITQ": "transmission_queue_name"
+      },
+      "response_value_map": {}
+    },
+    "chinit": {
+      "request_key_map": {
+        "command_scope": "CMDSCOPE",
+        "environment_info": "ENVPARM",
+        "initiation_queue_name": "INITQ",
+        "shared_channel_restart": "SHARED"
+      },
+      "request_value_map": {},
+      "response_key_map": {},
+      "response_value_map": {}
+    },
+    "chlauth": {
+      "request_key_map": {
+        "action": "ACTION",
+        "address_list": "ADDRLIST",
+        "address": "ADDRESS",
+        "check_client": "CHCKCLNT",
+        "client_user": "CLNTUSER",
+        "command_scope": "CMDSCOPE",
+        "custom": "CUSTOM",
+        "description": "DESCR",
+        "match": "MATCH",
+        "mca_user": "MCAUSER",
+        "queue_manager_name": "QMNAME",
+        "ssl_certificate_issuer": "SSLCERTI",
+        "ssl_peer_name": "SSLPEER",
+        "type": "TYPE",
+        "user_list": "USERLIST",
+        "user_source": "USERSRC",
+        "warn": "WARN"
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "ADDRESS": "address",
+        "ADDRLIST": "address_list",
+        "ALTDATE": "alteration_date",
+        "ALTTIME": "alteration_time",
+        "CHCKCLNT": "check_client",
+        "CLNTUSER": "client_user",
+        "CUSTOM": "custom",
+        "DESCR": "description",
+        "MCAUSER": "mca_user",
+        "QMNAME": "queue_manager_name",
+        "SSLCERTI": "ssl_certificate_issuer",
+        "SSLPEER": "ssl_peer_name",
+        "TYPE": "type",
+        "USERLIST": "user_list"
+      },
+      "response_value_map": {}
+    },
+    "chstatus": {
+      "request_key_map": {
+        "channel_disposition": "CHLDISP",
+        "command_scope": "CMDSCOPE",
+        "connection_name": "CONNAME",
+        "non_persistent_message_speed": "NPMSPEED",
+        "transmission_queue_name": "XMITQ"
+      },
+      "request_key_value_map": {
+        "channel_instance_type": {
+          "current": {
+            "key": "CURRENT",
+            "value": "YES"
+          },
+          "saved": {
+            "key": "SAVED",
+            "value": "YES"
+          },
+          "short": {
+            "key": "SHORT",
+            "value": "YES"
+          }
+        },
+        "monitor": {
+          "no": {
+            "key": "MONITOR",
+            "value": "NO"
+          },
+          "yes": {
+            "key": "MONITOR",
+            "value": "YES"
+          }
+        }
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "AMQPKA": "amqp_keep_alive",
+        "BATCHES": "batches",
+        "BATCHSZ": "batch_size",
+        "BUFSRCVD": "buffers_received",
+        "BUFSSENT": "buffers_sent",
+        "BYTSRCVD": "bytes_received",
+        "BYTSSENT": "bytes_sent",
+        "CHANNEL": "channel_name",
+        "CHLTYPE": "channel_type",
+        "CHSTADA": "channel_start_date",
+        "CHSTATI": "channel_start_time",
+        "COMPHDR": "header_compression",
+        "COMPMSG": "message_compression",
+        "COMPRATE": "compression_rate",
+        "COMPTIME": "compression_time",
+        "CONNAME": "connection_name",
+        "CURLUWID": "current_logical_unit_of_work_id",
+        "CURRENT": "current",
+        "CURMSGS": "current_messages",
+        "CURSEQNO": "current_sequence_number",
+        "CURSHCNV": "current_sharing_conversations",
+        "EXITTIME": "exit_time",
+        "HBINT": "heartbeat_interval",
+        "INDOUBT": "in_doubt_input",
+        "JOBNAME": "mca_job_name",
+        "KAINT": "keep_alive_interval",
+        "LOCLADDR": "local_address",
+        "LONGRTS": "long_retries_left",
+        "LSTLUWID": "last_logical_unit_of_work_id",
+        "LSTMSGDA": "last_message_date",
+        "LSTMSGTI": "last_message_time",
+        "LSTSEQNO": "last_sequence_number",
+        "MAXMSGL": "max_message_length",
+        "MAXSHCNV": "max_sharing_conversations",
+        "MCASTAT": "mca_status",
+        "MCAUSER": "mca_user",
+        "MONCHL": "channel_monitoring",
+        "MSGS": "messages",
+        "NETTIME": "net_time",
+        "NPMSPEED": "non_persistent_message_speed",
+        "PORT": "port",
+        "QMNAME": "queue_manager_name",
+        "RAPPLTAG": "remote_application_tag",
+        "RPRODUCT": "remote_product",
+        "RQMNAME": "remote_queue_manager_name",
+        "RVERSION": "remote_version",
+        "SECPROT": "security_protocol",
+        "SHORTRTS": "short_retries_left",
+        "SSLCERTI": "ssl_certificate_issuer",
+        "SSLCERTU": "ssl_certificate_user_id",
+        "SSLCIPH": "ssl_cipher_spec",
+        "SSLKEYDA": "ssl_key_reset_date",
+        "SSLKEYTI": "ssl_key_reset_time",
+        "SSLPEER": "ssl_peer_name",
+        "SSLRKEYS": "ssl_key_resets",
+        "STATCHL": "channel_statistics",
+        "STATUS": "channel_status",
+        "STOPREQ": "stop_requested",
+        "SUBSTATE": "sub_state",
+        "TPROOT": "topic_root",
+        "XMITQ": "transmission_queue_name",
+        "XBATCHSZ": "batch_size_indicator",
+        "XQMSGSA": "messages_available",
+        "XQTIME": "transmission_queue_time"
+      },
+      "response_value_map": {}
+    },
+    "clusqmgr": {
+      "request_key_map": {
+        "channel_name": "CHANNEL",
+        "cluster_name": "CLUSTER",
+        "command_scope": "CMDSCOPE"
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "CLUSDATE": "cluster_date",
+        "CLUSTIME": "cluster_time",
+        "DEFTYPE": "definition_type",
+        "QMID": "queue_manager_id",
+        "QMTYPE": "queue_manager_type",
+        "STATUS": "channel_status",
+        "SUSPEND": "suspend",
+        "VERSION": "version",
+        "XMITQ": "transmission_queue_name"
+      },
+      "response_value_map": {}
+    },
+    "cluster": {
+      "request_key_map": {
+        "action": "ACTION",
+        "command_scope": "CMDSCOPE",
+        "queue_manager_id": "QMID",
+        "queue_manager_name": "QMNAME",
+        "refresh_repository": "REPOS",
+        "remove_queues": "QUEUES"
+      },
+      "request_value_map": {},
+      "response_key_map": {},
+      "response_value_map": {}
+    },
+    "cmdserv": {
+      "request_key_map": {},
+      "request_value_map": {},
+      "response_key_map": {},
+      "response_value_map": {}
+    },
+    "comminfo": {
+      "request_key_map": {
+        "bridge": "BRIDGE",
+        "coded_character_set_id": "CCSID",
+        "communication_event": "COMMEV",
+        "description": "DESCR",
+        "encoding": "ENCODING",
+        "group_address": "GRPADDR",
+        "ignore_state": "IGNSTATE",
+        "like": "LIKE",
+        "message_history": "MSGHIST",
+        "monitor_interval": "MONINT",
+        "multicast_heartbeat": "MCHBINT",
+        "multicast_property_control": "MCPROP",
+        "new_subscription_history": "NSUBHIST",
+        "port": "PORT",
+        "type": "TYPE"
+      },
+      "request_key_value_map": {
+        "noreplace": {
+          "yes": {
+            "key": "REPLACE",
+            "value": "NO"
+          }
+        },
+        "replace": {
+          "no": {
+            "key": "REPLACE",
+            "value": "NO"
+          },
+          "yes": {
+            "key": "REPLACE",
+            "value": "YES"
+          }
+        }
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "ALTDATE": "alteration_date",
+        "ALTTIME": "alteration_time",
+        "BRIDGE": "bridge",
+        "CCSID": "coded_character_set_id",
+        "COMMEV": "communication_event",
+        "DESCR": "description",
+        "ENCODING": "encoding",
+        "GRPADDR": "group_address",
+        "MCHBINT": "multicast_heartbeat",
+        "MCPROP": "multicast_property_control",
+        "MONINT": "monitor_interval",
+        "MSGHIST": "message_history",
+        "NSUBHIST": "new_subscription_history",
+        "PORT": "port",
+        "TYPE": "type"
+      },
+      "response_value_map": {}
+    },
+    "conn": {
+      "request_key_map": {
+        "command_scope": "CMDSCOPE",
+        "connection_info_type": "TYPE",
+        "connection_prefix": "EXTCONN",
+        "unit_of_recovery_disposition": "URDISP"
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "APPLDESC": "application_description",
+        "APPLTAG": "application_tag",
+        "APPLTYPE": "application_type",
+        "CHANNEL": "channel_name",
+        "CLIENTID": "client_id",
+        "CONNAME": "connection_name",
+        "CONNOPTS": "connection_options",
+        "CONNTAG": "connection_tag",
+        "DEST": "destination",
+        "DESTQMGR": "destination_queue_manager",
+        "EXTURID": "unit_of_work_id",
+        "HSTATE": "handle_state",
+        "OBJNAME": "object_name",
+        "OBJTYPE": "object_type",
+        "OPENOPTS": "open_options",
+        "PID": "process_id",
+        "PSBNAME": "program_spec_block_name",
+        "PSTID": "partition_spec_table_region_id",
+        "QMURID": "queue_manager_unit_of_work_id",
+        "QSGDISP": "queue_sharing_group_disposition",
+        "READA": "read_ahead",
+        "SUBID": "subscription_id",
+        "SUBNAME": "subscription_name",
+        "TASKNO": "task_number",
+        "TID": "thread_id",
+        "TOPICSTR": "topic_string",
+        "TRANSID": "transaction_id",
+        "TYPE": "connection_info_type",
+        "UOWLOG": "start_unit_of_work_log_extent",
+        "UOWLOGDA": "unit_of_work_log_start_date",
+        "UOWLOGTI": "unit_of_work_log_start_time",
+        "UOWSTATE": "unit_of_work_state",
+        "UOWSTDA": "unit_of_work_start_date",
+        "UOWSTTI": "unit_of_work_start_time",
+        "URTYPE": "unit_of_work_type",
+        "USERID": "user_id"
+      },
+      "response_value_map": {}
+    },
+    "entauth": {
+      "request_key_map": {
+        "group_name": "GROUP",
+        "object_name": "OBJNAME",
+        "principal_name": "PRINCIPAL",
+        "service_component": "SERVCOMP"
+      },
+      "request_value_map": {},
+      "response_key_map": {},
+      "response_value_map": {}
+    },
+    "group": {
+      "request_key_map": {
+        "obsolete_db2_messages": "OBSMSGS"
+      },
+      "request_value_map": {},
+      "response_key_map": {},
+      "response_value_map": {}
+    },
+    "indoubt": {
+      "request_key_map": {
+        "command_scope": "CMDSCOPE",
+        "in_doubt": "ACTION",
+        "origin_id": "NID",
+        "queue_manager_name": "QMNAME"
+      },
+      "request_value_map": {},
+      "response_key_map": {},
+      "response_value_map": {}
+    },
+    "listener": {
+      "request_key_map": {
+        "adapter": "ADAPTER",
+        "backlog": "BACKLOG",
+        "command_scope": "CMDSCOPE",
+        "commands": "COMMANDS",
+        "description": "DESCR",
+        "ignore_state": "IGNSTATE",
+        "inbound_disposition": "INDISP",
+        "ip_address": "IPADDR",
+        "like": "LIKE",
+        "local_name": "LOCLNAME",
+        "lu_name": "LUNAME",
+        "netbios_names": "NTBNAMES",
+        "port": "PORT",
+        "sessions": "SESSIONS",
+        "socket": "SOCKET",
+        "start_mode": "CONTROL",
+        "transaction_program_name": "TPNAME",
+        "transport_type": "TRPTYPE"
+      },
+      "request_key_value_map": {
+        "noreplace": {
+          "yes": {
+            "key": "REPLACE",
+            "value": "NO"
+          }
+        },
+        "replace": {
+          "no": {
+            "key": "REPLACE",
+            "value": "NO"
+          },
+          "yes": {
+            "key": "REPLACE",
+            "value": "YES"
+          }
+        }
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "ADAPTER": "adapter",
+        "ALTDATE": "alteration_date",
+        "ALTTIME": "alteration_time",
+        "BACKLOG": "backlog",
+        "COMMANDS": "commands",
+        "CONTROL": "start_mode",
+        "DESCR": "description",
+        "IPADDR": "ip_address",
+        "LISTENER": "listener_name",
+        "LOCLNAME": "local_name",
+        "NTBNAMES": "netbios_names",
+        "PORT": "port",
+        "SESSIONS": "sessions",
+        "SOCKET": "socket",
+        "TPNAME": "transaction_program_name",
+        "TRPTYPE": "transport_type"
+      },
+      "response_value_map": {}
+    },
+    "log": {
+      "request_key_map": {
+        "command_scope": "CMDSCOPE",
+        "deallocate_interval": "DEALLCT",
+        "log_compression": "COMPLOG",
+        "max_archive_log": "MAXARCH",
+        "max_concurrent_offloads": "MAXCNOFF",
+        "max_read_tape_units": "MAXRTU",
+        "output_buffer_count": "WRTHRSH",
+        "z_hyper_link": "ZHYLINK",
+        "z_hyper_write": "ZHYWRITE"
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "COMMANDS": "commands"
+      },
+      "response_value_map": {}
+    },
+    "lsstatus": {
+      "request_key_map": {},
+      "request_value_map": {},
+      "response_key_map": {
+        "ADAPTER": "adapter",
+        "BACKLOG": "backlog",
+        "CONTROL": "start_mode",
+        "DESCR": "description",
+        "IPADDR": "ip_address",
+        "LOCLNAME": "local_name",
+        "NTBNAMES": "netbios_names",
+        "PID": "process_id",
+        "PORT": "port",
+        "SESSIONS": "sessions",
+        "SOCKET": "socket",
+        "STARTDA": "start_date",
+        "STARTTI": "start_time",
+        "STATUS": "status",
+        "TPNAME": "transaction_program_name",
+        "TRPTYPE": "transport_type"
+      },
+      "response_value_map": {}
+    },
+    "maxsmsgs": {
+      "request_key_map": {},
+      "request_value_map": {},
+      "response_key_map": {},
+      "response_value_map": {}
+    },
+    "namelist": {
+      "request_key_map": {
+        "command_scope": "CMDSCOPE",
+        "description": "DESCR",
+        "ignore_state": "IGNSTATE",
+        "like": "LIKE",
+        "namelist_type": "NLTYPE",
+        "names": "NAMES",
+        "queue_sharing_group_disposition": "QSGDISP"
+      },
+      "request_key_value_map": {
+        "noreplace": {
+          "yes": {
+            "key": "REPLACE",
+            "value": "NO"
+          }
+        },
+        "replace": {
+          "no": {
+            "key": "REPLACE",
+            "value": "NO"
+          },
+          "yes": {
+            "key": "REPLACE",
+            "value": "YES"
+          }
+        }
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "ALTDATE": "alteration_date",
+        "ALTTIME": "alteration_time",
+        "DESCR": "description",
+        "NAMCOUNT": "name_count",
+        "NAMELIST": "namelist_name",
+        "NAMES": "names"
+      },
+      "response_value_map": {}
+    },
+    "policy": {
+      "request_key_map": {
+        "action": "ACTION",
+        "encryption_algorithm": "ENCALG",
+        "enforce": "ENFORCE",
+        "ignore_state": "IGNSTATE",
+        "key_reuse": "KEYREUSE",
+        "recipient": "RECIP",
+        "sign_algorithm": "SIGNALG",
+        "signer": "SIGNER",
+        "tolerate": "TOLERATE"
+      },
+      "request_value_map": {},
+      "response_key_map": {},
+      "response_value_map": {}
+    },
+    "process": {
+      "request_key_map": {
+        "application_id": "APPLICID",
+        "application_type": "APPLTYPE",
+        "command_scope": "CMDSCOPE",
+        "description": "DESCR",
+        "environment_data": "ENVRDATA",
+        "ignore_state": "IGNSTATE",
+        "like": "LIKE",
+        "queue_sharing_group_disposition": "QSGDISP",
+        "user_data": "USERDATA"
+      },
+      "request_key_value_map": {
+        "noreplace": {
+          "yes": {
+            "key": "REPLACE",
+            "value": "NO"
+          }
+        },
+        "replace": {
+          "no": {
+            "key": "REPLACE",
+            "value": "NO"
+          },
+          "yes": {
+            "key": "REPLACE",
+            "value": "YES"
+          }
+        }
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "ALTDATE": "alteration_date",
+        "ALTTIME": "alteration_time",
+        "APPLICID": "application_id",
+        "APPLTYPE": "application_type",
+        "DESCR": "description",
+        "ENVRDATA": "environment_data",
+        "PROCESS": "process_name",
+        "USERDATA": "user_data"
+      },
+      "response_value_map": {}
+    },
+    "psid": {
+      "request_key_map": {},
+      "request_value_map": {},
+      "response_key_map": {},
+      "response_value_map": {}
+    },
+    "pubsub": {
+      "request_key_map": {
+        "command_scope": "CMDSCOPE",
+        "type": "TYPE"
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "QMNAME": "queue_manager_name",
+        "STATUS": "status",
+        "SUBCOUNT": "subscription_count",
+        "TPCOUNT": "topic_node_count"
+      },
+      "response_value_map": {}
+    },
+    "qmgr": {
+      "request_key_map": {
+        "accounting_connection_override": "ACCTCONO",
+        "accounting_interval": "ACCTINT",
+        "activity_connection_override": "ACTVCONO",
+        "activity_recording": "ACTIVREC",
+        "activity_trace": "ACTVTRC",
+        "adopt_new_mca_check": "ADOPTCHK",
+        "adopt_new_mca_type": "ADOPTMCA",
+        "authority_event": "AUTHOREV",
+        "authority_event_scope": "AUTHEVSC",
+        "bridge_event": "BRIDGEEV",
+        "certificate_label": "CERTLABL",
+        "certificate_validation_policy": "CERTVPOL",
+        "cf_connection_lost": "CFCONLOS",
+        "channel_authentication_records": "CHLAUTH",
+        "channel_auto_define": "CHAD",
+        "channel_auto_define_event": "CHADEV",
+        "channel_auto_define_exit": "CHADEXIT",
+        "channel_event": "CHLEV",
+        "channel_initiator_control": "SCHINIT",
+        "channel_monitoring": "MONCHL",
+        "channel_statistics": "STATCHL",
+        "chinit_adapters": "CHIADAPS",
+        "chinit_dispatchers": "CHIDISPS",
+        "chinit_service_parameter": "CHISERVP",
+        "chinit_trace_auto_start": "TRAXSTR",
+        "chinit_trace_table_size": "TRAXTBL",
+        "cluster_namelist": "CLUSNL",
+        "cluster_sender_monitoring_default": "MONACLS",
+        "cluster_sender_statistics": "STATACLS",
+        "cluster_work_load_data": "CLWLDATA",
+        "cluster_work_load_exit": "CLWLEXIT",
+        "cluster_work_load_length": "CLWLLEN",
+        "cluster_workload_mru_channels": "CLWLMRUC",
+        "cluster_workload_use_queue": "CLWLUSEQ",
+        "coded_character_set_id": "CCSID",
+        "command_event": "CMDEV",
+        "command_scope": "CMDSCOPE",
+        "command_server_control": "SCMDSERV",
+        "configuration_event": "CONFIGEV",
+        "connection_authentication": "CONNAUTH",
+        "custom": "CUSTOM",
+        "dead_letter_queue_name": "DEADQ",
+        "default_cluster_transmission_queue_type": "DEFCLXQ",
+        "default_transmission_queue_name": "DEFXMITQ",
+        "description": "DESCR",
+        "encryption_policy_suite_b": "SUITEB",
+        "expiry_interval": "EXPRYINT",
+        "facility": "FACILITY",
+        "force": "FORCE",
+        "group_unit_of_recovery": "GROUPUR",
+        "intragroup_queueing_put_authority": "IGQAUT",
+        "intragroup_queueing_user_id": "IGQUSER",
+        "image_interval": "IMGINTVL",
+        "image_log_length": "IMGLOGLN",
+        "image_recover_object": "IMGRCOVO",
+        "image_recover_queue": "IMGRCOVQ",
+        "image_schedule": "IMGSCHED",
+        "inhibit_event": "INHIBTEV",
+        "initial_key": "INITKEY",
+        "ip_address_version": "IPADDRV",
+        "listener_timer": "LSTRTMR",
+        "local_event": "LOCALEV",
+        "logger_event": "LOGGEREV",
+        "lu62_arm_suffix": "LU62ARM",
+        "lu62_channels": "LU62CHL",
+        "lu_group_name": "LUGROUP",
+        "lu_name": "LUNAME",
+        "max_active_channels": "ACTCHL",
+        "max_channels": "MAXCHL",
+        "max_handles": "MAXHANDS",
+        "max_message_length": "MAXMSGL",
+        "max_properties_length": "MAXPROPL",
+        "max_uncommitted_messages": "MAXUMSGS",
+        "message_mark_browse_interval": "MARKINT",
+        "mqi_accounting": "ACCTMQI",
+        "mqi_statistics": "STATMQI",
+        "native_ha_type": "NHATYPE",
+        "object_type": "OBJECT",
+        "otel_propagation_control": "OTELPCTL",
+        "otel_trace": "OTELTRAC",
+        "outbound_port_max": "OPORTMAX",
+        "outbound_port_min": "OPORTMIN",
+        "parent": "PARENT",
+        "performance_event": "PERFMEV",
+        "pub_sub_cluster": "PSCLUS",
+        "pub_sub_max_message_retry_count": "PSRTYCNT",
+        "pub_sub_mode": "PSMODE",
+        "pub_sub_non_persistent_input_message": "PSNPMSG",
+        "pub_sub_non_persistent_response": "PSNPRES",
+        "pub_sub_sync_point": "PSSYNCPT",
+        "queue_sharing_group_certificate_label": "CERTQSGL",
+        "queue_accounting": "ACCTQ",
+        "queue_monitoring": "MONQ",
+        "queue_statistics": "STATQ",
+        "receive_timeout": "RCVTIME",
+        "receive_timeout_min": "RCVTMIN",
+        "receive_timeout_type": "RCVTTYPE",
+        "refresh_interval": "INCLINT",
+        "remote_event": "REMOTEEV",
+        "repository_name": "REPOS",
+        "repository_namelist": "REPOSNL",
+        "reverse_dns": "REVDNS",
+        "security_case": "SCYCASE",
+        "shared_queue_queue_manager_name": "SQQMNAME",
+        "ssl_crypto_hardware": "SSLCRYP",
+        "ssl_event": "SSLEV",
+        "ssl_fips_required": "SSLFIPS",
+        "ssl_key_repository": "SSLKEYR",
+        "ssl_key_repository_password": "KEYRPWD",
+        "ssl_key_reset_count": "SSLRKEYC",
+        "ssl_tasks": "SSLTASKS",
+        "sslcrl_namelist": "SSLCRLNL",
+        "start_stop_event": "STRSTPEV",
+        "statistics_interval": "STATINT",
+        "status_type": "TYPE",
+        "tcp_channels": "TCPCHL",
+        "tcp_keep_alive": "TCPKEEP",
+        "tcp_name": "TCPNAME",
+        "tcp_stack_type": "TCPSTACK",
+        "trace_route_recording": "ROUTEREC",
+        "tree_life_time": "TREELIFE",
+        "trigger_interval": "TRIGINT"
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "ACCTCONO": "accounting_connection_override",
+        "ACCTINT": "accounting_interval",
+        "ACCTMQI": "mqi_accounting",
+        "ACCTQ": "queue_accounting",
+        "ACTCHL": "max_active_channels",
+        "ACTIVREC": "activity_recording",
+        "ACTVCONO": "activity_connection_override",
+        "ACTVTRC": "activity_trace",
+        "ADOPTCHK": "adopt_new_mca_check",
+        "ADOPTMCA": "adopt_new_mca_type",
+        "ADVCAP": "advanced_capability",
+        "ALTDATE": "alteration_date",
+        "ALTTIME": "alteration_time",
+        "AMQPCAP": "amqp_capability",
+        "ARCHLOG": "archive_log",
+        "ARCHSZ": "archive_log_size",
+        "AUTHEVSC": "authority_event_scope",
+        "AUTHOREV": "authority_event",
+        "AUTOCLUS": "auto_cluster",
+        "BRIDGEEV": "bridge_event",
+        "CCSID": "coded_character_set_id",
+        "CERTLABL": "certificate_label",
+        "CERTQSGL": "queue_sharing_group_certificate_label",
+        "CERTVPOL": "certificate_validation_policy",
+        "CFCONLOS": "cf_connection_lost",
+        "CHAD": "channel_auto_define",
+        "CHADEV": "channel_auto_define_event",
+        "CHADEXIT": "channel_auto_define_exit",
+        "CHIADAPS": "chinit_adapters",
+        "CHIDISPS": "chinit_dispatchers",
+        "CHISERVP": "chinit_service_parameter",
+        "CHKPTCNT": "checkpoint_count",
+        "CHKPTOPS": "checkpoint_operations",
+        "CHKPTSZ": "checkpoint_size",
+        "CHLAUTH": "channel_authentication_records",
+        "CHLEV": "channel_event",
+        "CLWLDATA": "cluster_work_load_data",
+        "CLWLEXIT": "cluster_work_load_exit",
+        "CLWLLEN": "cluster_work_load_length",
+        "CLWLMRUC": "cluster_workload_mru_channels",
+        "CLWLUSEQ": "cluster_workload_use_queue",
+        "CMDEV": "command_event",
+        "CMDLEVEL": "command_level",
+        "CMDSERV": "command_server_status",
+        "COMMANDQ": "command_input_queue_name",
+        "CONFIGEV": "configuration_event",
+        "CONNAUTH": "connection_authentication",
+        "CPILEVEL": "cpi_level",
+        "CRDATE": "creation_date",
+        "CRTIME": "creation_time",
+        "CURRLOG": "current_log",
+        "CUSTOM": "custom",
+        "DATFSSZ": "data_filesystem_size",
+        "DATFSUSE": "data_filesystem_use",
+        "DATPATH": "data_path",
+        "DEADQ": "dead_letter_queue_name",
+        "DEFCLXQ": "default_cluster_transmission_queue_type",
+        "DEFXMITQ": "default_transmission_queue_name",
+        "DESCR": "description",
+        "DISKLSN": "disk_log_sequence_number",
+        "DISTL": "distribution_lists",
+        "EXPRYINT": "expiry_interval",
+        "GROUPUR": "group_unit_of_recovery",
+        "GRPLSN": "group_log_sequence_number",
+        "GRPNAME": "group_name",
+        "GRPROLE": "group_role",
+        "HOSTNAME": "host_name",
+        "IGQAUT": "intragroup_queueing_put_authority",
+        "IGQUSER": "intragroup_queueing_user_id",
+        "IMGINTVL": "image_interval",
+        "IMGLOGLN": "image_log_length",
+        "IMGRCOVO": "image_recover_object",
+        "IMGRCOVQ": "image_recover_queue",
+        "IMGSCHED": "image_schedule",
+        "INHIBTEV": "inhibit_event",
+        "INITKEY": "initial_key",
+        "INSTANCE": "instance",
+        "INSTDESC": "installation_description",
+        "INSTNAME": "installation_name",
+        "INSTPATH": "installation_path",
+        "IPADDRV": "ip_address_version",
+        "KEYRPWD": "ssl_key_repository_password",
+        "LDAPCONN": "ldap_connection_status",
+        "LOCALEV": "local_event",
+        "LOGEXTSZ": "log_ext_size",
+        "LOGFSSZ": "log_filesystem_size",
+        "LOGFSUSE": "log_filesystem_use",
+        "LOGGEREV": "logger_event",
+        "LOGINUSE": "log_in_use",
+        "LOGPATH": "log_path",
+        "LOGPRIM": "log_primary",
+        "LOGSEC": "log_secondary",
+        "LOGSTRDA": "log_start_date",
+        "LOGSTRL": "log_start_log_sequence_number",
+        "LOGSTRTI": "log_start_time",
+        "LOGTYPE": "log_type",
+        "LOGUTIL": "log_utilization",
+        "LSTRTMR": "listener_timer",
+        "LU62ARM": "lu62_arm_suffix",
+        "LU62CHL": "lu62_channels",
+        "LUGROUP": "lu_group_name",
+        "LUNAME": "lu_name",
+        "MARKINT": "message_mark_browse_interval",
+        "MAXCHL": "max_channels",
+        "MAXHANDS": "max_handles",
+        "MAXMSGL": "max_message_length",
+        "MAXPROPL": "max_properties_length",
+        "MAXPRTY": "max_priority",
+        "MAXUMSGS": "max_uncommitted_messages",
+        "MEDIALOG": "media_recovery_log_extent",
+        "MEDIASZ": "media_recovery_log_size",
+        "MONACLS": "cluster_sender_monitoring_default",
+        "MONCHL": "channel_monitoring",
+        "MONQ": "queue_monitoring",
+        "OPORTMAX": "outbound_port_max",
+        "OPORTMIN": "outbound_port_min",
+        "OTELPCTL": "otel_propagation_control",
+        "OTELTRAC": "otel_trace",
+        "PARENT": "parent",
+        "PERFMEV": "performance_event",
+        "PLATFORM": "platform",
+        "PSCLUS": "pub_sub_cluster",
+        "PSMODE": "pub_sub_mode",
+        "PSNPMSG": "pub_sub_non_persistent_input_message",
+        "PSNPRES": "pub_sub_non_persistent_response",
+        "PSRTYCNT": "pub_sub_max_message_retry_count",
+        "PSSYNCPT": "pub_sub_sync_point",
+        "QMFSENC": "queue_manager_encryption",
+        "QMFSSZ": "queue_manager_filesystem_size",
+        "QMFSUSE": "queue_manager_filesystem_use",
+        "QMID": "queue_manager_id",
+        "QMNAME": "queue_manager_name",
+        "QSGNAME": "queue_sharing_group_name",
+        "QUORUM": "quorum",
+        "RCVTIME": "receive_timeout",
+        "RCVTMIN": "receive_timeout_min",
+        "RCVTTYPE": "receive_timeout_type",
+        "REMOTEEV": "remote_event",
+        "REPOS": "repository_name",
+        "REPOSNL": "repository_namelist",
+        "REUSESZ": "reusable_log_size",
+        "REVDNS": "reverse_dns",
+        "ROUTEREC": "trace_route_recording",
+        "SCHINIT": "channel_initiator_control",
+        "SCMDSERV": "command_server_control",
+        "SCYCASE": "security_case",
+        "SPLCAP": "security_policy_capability",
+        "SQQMNAME": "shared_queue_queue_manager_name",
+        "SSLCRLNL": "sslcrl_namelist",
+        "SSLCRYP": "ssl_crypto_hardware",
+        "SSLEV": "ssl_event",
+        "SSLFIPS": "ssl_fips_required",
+        "SSLKEYR": "ssl_key_repository",
+        "SSLRKEYC": "ssl_key_reset_count",
+        "SSLTASKS": "ssl_tasks",
+        "STANDBY": "permit_standby",
+        "STARTDA": "start_date",
+        "STARTTI": "start_time",
+        "STATACLS": "cluster_sender_statistics",
+        "STATCHL": "channel_statistics",
+        "STATINT": "statistics_interval",
+        "STATMQI": "mqi_statistics",
+        "STATQ": "queue_statistics",
+        "STATUS": "ha_status",
+        "STRSTPEV": "start_stop_event",
+        "SUITEB": "encryption_policy_suite_b",
+        "SYNCPT": "sync_point",
+        "TCPCHL": "tcp_channels",
+        "TCPKEEP": "tcp_keep_alive",
+        "TCPNAME": "tcp_name",
+        "TCPSTACK": "tcp_stack_type",
+        "TRAXSTR": "chinit_trace_auto_start",
+        "TRAXTBL": "chinit_trace_table_size",
+        "TREELIFE": "tree_life_time",
+        "TRIGINT": "trigger_interval",
+        "UNICLUS": "uniform_cluster_name",
+        "VERSION": "version",
+        "XRCAP": "telemetry_capability"
+      },
+      "response_value_map": {}
+    },
+    "qmstatus": {
+      "request_key_map": {
+        "native_ha_type": "NHATYPE",
+        "status_type": "TYPE"
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "ARCHLOG": "archive_log",
+        "ARCHSZ": "archive_log_size",
+        "AUTOCLUS": "auto_cluster",
+        "CHINIT": "channel_initiator_status",
+        "CHKPTCNT": "checkpoint_count",
+        "CHKPTOPS": "checkpoint_operations",
+        "CHKPTSZ": "checkpoint_size",
+        "CMDSERV": "command_server_status",
+        "CONNS": "connections",
+        "CURRLOG": "current_log",
+        "DATFSSZ": "data_filesystem_size",
+        "DATFSUSE": "data_filesystem_use",
+        "DATPATH": "data_path",
+        "DISKLSN": "disk_log_sequence_number",
+        "GRPLSN": "group_log_sequence_number",
+        "GRPNAME": "group_name",
+        "GRPROLE": "group_role",
+        "HOSTNAME": "host_name",
+        "INSTANCE": "instance",
+        "INSTDESC": "installation_description",
+        "INSTNAME": "installation_name",
+        "INSTPATH": "installation_path",
+        "LDAPCONN": "ldap_connection_status",
+        "LOGEXTSZ": "log_ext_size",
+        "LOGFSSZ": "log_filesystem_size",
+        "LOGFSUSE": "log_filesystem_use",
+        "LOGINUSE": "log_in_use",
+        "LOGPATH": "log_path",
+        "LOGPRIM": "log_primary",
+        "LOGSEC": "log_secondary",
+        "LOGSTRDA": "log_start_date",
+        "LOGSTRL": "log_start_log_sequence_number",
+        "LOGSTRTI": "log_start_time",
+        "LOGTYPE": "log_type",
+        "LOGUTIL": "log_utilization",
+        "MEDIALOG": "media_recovery_log_extent",
+        "MEDIASZ": "media_recovery_log_size",
+        "QMFSENC": "queue_manager_encryption",
+        "QMFSSZ": "queue_manager_filesystem_size",
+        "QMFSUSE": "queue_manager_filesystem_use",
+        "QMNAME": "queue_manager_name",
+        "QUORUM": "quorum",
+        "RECLOG": "recovery_log",
+        "RECSZ": "recovery_log_size",
+        "REUSESZ": "reusable_log_size",
+        "STANDBY": "permit_standby",
+        "STARTDA": "start_date",
+        "STARTTI": "start_time",
+        "STATUS": "ha_status",
+        "TYPE": "status_type",
+        "UNICLUS": "uniform_cluster_name"
+      },
+      "response_value_map": {}
+    },
+    "queue": {
+      "request_key_map": {
+        "authorization_record": "AUTHREC",
+        "backout_requeue_name": "BOQNAME",
+        "backout_threshold": "BOTHRESH",
+        "cf_struct_name": "CFSTRUCT",
+        "cluster_channel_name": "CLCHNAME",
+        "cluster_name": "CLUSTER",
+        "cluster_namelist": "CLUSNL",
+        "cluster_workload_priority": "CLWLPRTY",
+        "cluster_workload_rank": "CLWLRANK",
+        "cluster_workload_use_queue": "CLWLUSEQ",
+        "command_scope": "CMDSCOPE",
+        "custom": "CUSTOM",
+        "default_bind": "DEFBIND",
+        "default_input_open_option": "DEFSOPT",
+        "default_persistence": "DEFPSIST",
+        "default_priority": "DEFPRTY",
+        "default_read_ahead": "DEFREADA",
+        "default_put_response": "DEFPRESP",
+        "definition_type": "DEFTYPE",
+        "description": "DESCR",
+        "distribution_lists": "DISTL",
+        "force": "FORCE",
+        "harden_get_backout": "HARDENBO",
+        "ignore_state": "IGNSTATE",
+        "image_recover_queue": "IMGRCOVQ",
+        "inhibit_get": "GET",
+        "inhibit_put": "PUT",
+        "initiation_queue_name": "INITQ",
+        "like": "LIKE",
+        "max_message_length": "MAXMSGL",
+        "max_queue_depth": "MAXDEPTH",
+        "max_queue_file_size": "MAXFSIZE",
+        "message_delivery_sequence": "MSGDLVSQ",
+        "non_persistent_message_class": "NPMCLASS",
+        "page_set_id": "PSID",
+        "process_name": "PROCESS",
+        "property_control": "PROPCTL",
+        "queue_depth_high_event": "QDPHIEV",
+        "queue_depth_high_limit": "QDEPTHHI",
+        "queue_depth_low_event": "QDPLOEV",
+        "queue_depth_low_limit": "QDEPTHLO",
+        "queue_depth_max_event": "QDPMAXEV",
+        "queue_service_interval": "QSVCINT",
+        "queue_sharing_group_disposition": "QSGDISP",
+        "queue_accounting": "ACCTQ",
+        "queue_monitoring": "MONQ",
+        "queue_statistics": "STATQ",
+        "remote_queue_manager_name": "RQMNAME",
+        "remote_queue_name": "RNAME",
+        "retention_interval": "RETINTVL",
+        "scope": "SCOPE",
+        "shareability": "SHARE",
+        "storage_class": "STGCLASS",
+        "stream_queue": "STREAMQ",
+        "stream_queue_service": "STRMQOS",
+        "target_queue_name": "TARGET",
+        "target_type": "TARGTYPE",
+        "to_queue_name": "TOQLOCAL",
+        "transmission_queue_name": "XMITQ",
+        "trigger_control": "TRIGGER",
+        "trigger_data": "TRIGDATA",
+        "trigger_depth": "TRIGDPTH",
+        "trigger_message_priority": "TRIGMPRI",
+        "trigger_type": "TRIGTYPE",
+        "usage": "USAGE"
+      },
+      "request_key_value_map": {
+        "nopurge": {
+          "yes": {
+            "key": "PURGE",
+            "value": "NO"
+          }
+        },
+        "noreplace": {
+          "yes": {
+            "key": "REPLACE",
+            "value": "NO"
+          }
+        },
+        "purge": {
+          "no": {
+            "key": "PURGE",
+            "value": "NO"
+          },
+          "yes": {
+            "key": "PURGE",
+            "value": "YES"
+          }
+        },
+        "replace": {
+          "no": {
+            "key": "REPLACE",
+            "value": "NO"
+          },
+          "yes": {
+            "key": "REPLACE",
+            "value": "YES"
+          }
+        }
+      },
+      "request_value_map": {
+        "default_persistence": {
+          "def": "DEF",
+          "no": "NO",
+          "not_fixed": "NOTFIXED",
+          "yes": "YES"
+        }
+      },
+      "response_key_map": {
+        "ACCTQ": "queue_accounting",
+        "ALTDATE": "alteration_date",
+        "ALTTIME": "alteration_time",
+        "APPLDESC": "application_description",
+        "APPLTAG": "application_tag",
+        "APPLTYPE": "application_type",
+        "ASID": "address_space_id",
+        "ASTATE": "asynchronous_state",
+        "BOQNAME": "backout_requeue_name",
+        "BOTHRESH": "backout_threshold",
+        "BROWSE": "open_browse",
+        "CAPEXPRY": "cap_expiry",
+        "CFSTRUCT": "cf_struct_name",
+        "CHANNEL": "channel_name",
+        "CLCHNAME": "cluster_channel_name",
+        "CLUSDATE": "cluster_date",
+        "CLUSNL": "cluster_namelist",
+        "CLUSQMGR": "cluster_queue_manager",
+        "CLUSQT": "cluster_queue_type",
+        "CLUSTER": "cluster_name",
+        "CLUSTIME": "cluster_time",
+        "CLWLPRTY": "cluster_workload_priority",
+        "CLWLRANK": "cluster_workload_rank",
+        "CLWLUSEQ": "cluster_workload_use_queue",
+        "CONNAME": "connection_name",
+        "CRDATE": "creation_date",
+        "CRTIME": "creation_time",
+        "CURDEPTH": "current_queue_depth",
+        "CURFSIZE": "current_queue_file_size",
+        "CURMAXFS": "current_max_queue_file_size",
+        "CUSTOM": "custom",
+        "DEFBIND": "default_bind",
+        "DEFPRESP": "default_put_response",
+        "DEFPRTY": "default_priority",
+        "DEFPSIST": "default_persistence",
+        "DEFREADA": "default_read_ahead",
+        "DEFSOPT": "default_input_open_option",
+        "DEFTYPE": "definition_type",
+        "DESCR": "description",
+        "DISTL": "distribution_lists",
+        "GET": "inhibit_get",
+        "HARDENBO": "harden_get_backout",
+        "HSTATE": "handle_state",
+        "IMGRCOVQ": "image_recover_queue",
+        "INDXTYPE": "index_type",
+        "INITQ": "initiation_queue_name",
+        "INQUIRE": "open_inquire",
+        "IPPROCS": "open_input_count",
+        "LGETDATE": "last_get_date",
+        "LGETTIME": "last_get_time",
+        "LPUTDATE": "last_put_date",
+        "LPUTTIME": "last_put_time",
+        "MAXDEPTH": "max_queue_depth",
+        "MAXFSIZE": "max_queue_file_size",
+        "MAXMSGL": "max_message_length",
+        "MEDIALOG": "media_recovery_log_extent",
+        "MONQ": "queue_monitoring",
+        "MSGAGE": "oldest_message_age",
+        "MSGDLVSQ": "message_delivery_sequence",
+        "NOSHARE": "no_share",
+        "NOTRIGGER": "no_trigger",
+        "NPMCLASS": "non_persistent_message_class",
+        "OPPROCS": "open_output_count",
+        "OTELPCTL": "otel_propagation_control",
+        "OTELTRAC": "otel_trace",
+        "OUTPUT": "open_output",
+        "PID": "process_id",
+        "PROCESS": "process_name",
+        "PROPCTL": "property_control",
+        "PSBNAME": "program_spec_block_name",
+        "PSID": "page_set_id",
+        "PSTID": "partition_spec_table_region_id",
+        "PUT": "inhibit_put",
+        "QDEPTHHI": "queue_depth_high_limit",
+        "QDEPTHLO": "queue_depth_low_limit",
+        "QDPHIEV": "queue_depth_high_event",
+        "QDPLOEV": "queue_depth_low_event",
+        "QDPMAXEV": "queue_depth_max_event",
+        "QMID": "queue_manager_id",
+        "QMURID": "queue_manager_unit_of_work_id",
+        "QSGDISP": "queue_sharing_group_disposition",
+        "QSVCIEV": "queue_service_interval_event",
+        "QSVCINT": "queue_service_interval",
+        "QTIME": "on_queue_time",
+        "QTYPE": "queue_type",
+        "QUEUE": "queue_name",
+        "RETINTVL": "retention_interval",
+        "RNAME": "remote_queue_name",
+        "RQMNAME": "remote_queue_manager_name",
+        "SCOPE": "scope",
+        "SET": "open_set",
+        "SHARE": "shareability",
+        "STATQ": "queue_statistics",
+        "STGCLASS": "storage_class",
+        "STREAMQ": "stream_queue",
+        "STRMQOS": "stream_queue_service",
+        "TARGET": "target_queue_name",
+        "TARGTYPE": "target_type",
+        "TASKNO": "task_number",
+        "TID": "thread_id",
+        "TPIPE": "tpipe_names",
+        "TRANSID": "transaction_id",
+        "TYPE": "type",
+        "TRIGDATA": "trigger_data",
+        "TRIGDPTH": "trigger_depth",
+        "TRIGGER": "trigger_control",
+        "TRIGMPRI": "trigger_message_priority",
+        "TRIGTYPE": "trigger_type",
+        "UNCOM": "uncommitted_messages",
+        "URID": "unit_of_work_id",
+        "URTYPE": "unit_of_work_type",
+        "USAGE": "usage",
+        "USERID": "user_id",
+        "XMITQ": "transmission_queue_name"
+      },
+      "response_value_map": {
+        "DEFPSIST": {
+          "DEF": "def",
+          "NO": "no",
+          "NOTFIXED": "not_fixed",
+          "YES": "yes"
+        }
+      }
+    },
+    "qstatus": {
+      "request_key_map": {
+        "command_scope": "CMDSCOPE"
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "APPLDESC": "application_description",
+        "APPLTAG": "application_tag",
+        "APPLTYPE": "application_type",
+        "ASID": "address_space_id",
+        "ASTATE": "asynchronous_state",
+        "BROWSE": "open_browse",
+        "CHANNEL": "channel_name",
+        "CONNAME": "connection_name",
+        "CURDEPTH": "current_queue_depth",
+        "CURFSIZE": "current_queue_file_size",
+        "CURMAXFS": "current_max_queue_file_size",
+        "HSTATE": "handle_state",
+        "INPUT": "open_input",
+        "INQUIRE": "open_inquire",
+        "IPPROCS": "open_input_count",
+        "LGETDATE": "last_get_date",
+        "LGETTIME": "last_get_time",
+        "LPUTDATE": "last_put_date",
+        "LPUTTIME": "last_put_time",
+        "MEDIALOG": "media_recovery_log_extent",
+        "MONQ": "queue_monitoring",
+        "MSGAGE": "oldest_message_age",
+        "OPPROCS": "open_output_count",
+        "OUTPUT": "open_output",
+        "PID": "process_id",
+        "PSBNAME": "program_spec_block_name",
+        "PSTID": "partition_spec_table_region_id",
+        "QMURID": "queue_manager_unit_of_work_id",
+        "QSGDISP": "queue_sharing_group_disposition",
+        "QTIME": "on_queue_time",
+        "QUEUE": "queue_name",
+        "SET": "open_set",
+        "TASKNO": "task_number",
+        "TID": "thread_id",
+        "TRANSID": "transaction_id",
+        "TYPE": "status_type",
+        "UNCOM": "uncommitted_messages",
+        "URID": "unit_of_work_id",
+        "URTYPE": "unit_of_work_type",
+        "USERID": "user_id"
+      },
+      "response_value_map": {}
+    },
+    "sbstatus": {
+      "request_key_map": {
+        "command_scope": "CMDSCOPE",
+        "durable": "DURABLE",
+        "subscription_type": "SUBTYPE"
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "ACTCONN": "active_connection",
+        "DURABLE": "durable",
+        "LMSGDATE": "last_message_date",
+        "LMSGTIME": "last_message_time",
+        "MCASTREL": "multicast_reliability_indicator",
+        "NUMMSGS": "number_of_messages",
+        "RESMDATE": "resume_date",
+        "RESMTIME": "resume_time",
+        "SUBID": "subscription_id",
+        "SUBTYPE": "subscription_type",
+        "SUBUSER": "subscription_user_id",
+        "TOPICSTR": "topic_string"
+      },
+      "response_value_map": {}
+    },
+    "security": {
+      "request_key_map": {
+        "command_scope": "CMDSCOPE",
+        "security_interval": "INTERVAL",
+        "security_timeout": "TIMEOUT",
+        "security_type": "TYPE"
+      },
+      "request_value_map": {},
+      "response_key_map": {},
+      "response_value_map": {}
+    },
+    "service": {
+      "request_key_map": {
+        "description": "DESCR",
+        "ignore_state": "IGNSTATE",
+        "like": "LIKE",
+        "service_type": "SERVTYPE",
+        "start_arguments": "STARTARG",
+        "start_command": "STARTCMD",
+        "start_mode": "CONTROL",
+        "stderr_destination": "STDERR",
+        "stdout_destination": "STDOUT",
+        "stop_arguments": "STOPARG",
+        "stop_command": "STOPCMD"
+      },
+      "request_key_value_map": {
+        "noreplace": {
+          "yes": {
+            "key": "REPLACE",
+            "value": "NO"
+          }
+        },
+        "replace": {
+          "no": {
+            "key": "REPLACE",
+            "value": "NO"
+          },
+          "yes": {
+            "key": "REPLACE",
+            "value": "YES"
+          }
+        }
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "ALTDATE": "alteration_date",
+        "ALTTIME": "alteration_time",
+        "CONTROL": "start_mode",
+        "DESCR": "description",
+        "SERVTYPE": "service_type",
+        "STARTARG": "start_arguments",
+        "STARTCMD": "start_command",
+        "STDERR": "stderr_destination",
+        "STDOUT": "stdout_destination",
+        "STOPARG": "stop_arguments",
+        "STOPCMD": "stop_command"
+      },
+      "response_value_map": {}
+    },
+    "smds": {
+      "request_key_map": {
+        "access": "ACCESS",
+        "cf_struct_name": "CFSTRUCT",
+        "data_sharing_buffers": "DSBUFS",
+        "data_sharing_expand": "DSEXPAND",
+        "status": "STATUS"
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "CFSTRUCT": "cf_struct_name",
+        "DSBUFS": "data_sharing_buffers",
+        "DSEXPAND": "data_sharing_expand",
+        "SMDS": "shared_message_dataset"
+      },
+      "response_value_map": {}
+    },
+    "smdsconn": {
+      "request_key_map": {
+        "cf_struct_name": "CFSTRUCT",
+        "command_scope": "CMDSCOPE"
+      },
+      "request_value_map": {},
+      "response_key_map": {},
+      "response_value_map": {}
+    },
+    "stgclass": {
+      "request_key_map": {
+        "command_scope": "CMDSCOPE",
+        "description": "DESCR",
+        "like": "LIKE",
+        "page_set_id": "PSID",
+        "pass_ticket_application": "PASSTKTA",
+        "queue_sharing_group_disposition": "QSGDISP",
+        "xcf_group_name": "XCFGNAME",
+        "xcf_member_name": "XCFMNAME"
+      },
+      "request_key_value_map": {
+        "noreplace": {
+          "yes": {
+            "key": "REPLACE",
+            "value": "NO"
+          }
+        },
+        "replace": {
+          "no": {
+            "key": "REPLACE",
+            "value": "NO"
+          },
+          "yes": {
+            "key": "REPLACE",
+            "value": "YES"
+          }
+        }
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "ALTDATE": "alteration_date",
+        "ALTTIME": "alteration_time",
+        "DESCR": "description",
+        "PASSTKTA": "pass_ticket_application",
+        "XCFGNAME": "xcf_group_name",
+        "XCFMNAME": "xcf_member_name"
+      },
+      "response_value_map": {}
+    },
+    "sub": {
+      "request_key_map": {
+        "alteration_date": "ALTDATE",
+        "alteration_time": "ALTTIME",
+        "command_scope": "CMDSCOPE",
+        "creation_date": "CRDATE",
+        "creation_time": "CRTIME",
+        "destination": "DEST",
+        "destination_class": "DESTCLAS",
+        "destination_correlation_id": "DESTCORL",
+        "destination_queue_manager": "DESTQMGR",
+        "display_type": "DISTYPE",
+        "durable": "DURABLE",
+        "expiry": "EXPIRY",
+        "ignore_state": "IGNSTATE",
+        "publish_priority": "PUBPRTY",
+        "publish_subscribe_properties": "PSPROP",
+        "published_accounting_token": "PUBACCT",
+        "published_application_id": "PUBAPPID",
+        "request_only": "REQONLY",
+        "selector": "SELECTOR",
+        "selector_type": "SELTYPE",
+        "subscription_id": "SUBID",
+        "subscription_level": "SUBLEVEL",
+        "subscription_type": "SUBTYPE",
+        "subscription_user_id": "SUBUSER",
+        "topic_object": "TOPICOBJ",
+        "topic_string": "TOPICSTR",
+        "user_data": "USERDATA",
+        "variable_user": "VARUSER",
+        "wildcard_schema": "WSCHEMA"
+      },
+      "request_key_value_map": {
+        "noreplace": {
+          "yes": {
+            "key": "REPLACE",
+            "value": "NO"
+          }
+        },
+        "replace": {
+          "no": {
+            "key": "REPLACE",
+            "value": "NO"
+          },
+          "yes": {
+            "key": "REPLACE",
+            "value": "YES"
+          }
+        }
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "ALTDATE": "alteration_date",
+        "ALTTIME": "alteration_time",
+        "CMDSCOPE": "command_scope",
+        "CRDATE": "creation_date",
+        "CRTIME": "creation_time",
+        "DEST": "destination",
+        "DESTCLAS": "destination_class",
+        "DESTCORL": "destination_correlation_id",
+        "DESTQMGR": "destination_queue_manager",
+        "DISTYPE": "display_type",
+        "DURABLE": "durable",
+        "EXPIRY": "expiry",
+        "PSPROP": "publish_subscribe_properties",
+        "PUBACCT": "published_accounting_token",
+        "PUBAPPID": "published_application_id",
+        "PUBPRTY": "publish_priority",
+        "REQONLY": "request_only",
+        "SELECTOR": "selector",
+        "SELTYPE": "selector_type",
+        "SUB": "subscription_name",
+        "SUBID": "subscription_id",
+        "SUBLEVEL": "subscription_level",
+        "SUBTYPE": "subscription_type",
+        "SUBUSER": "subscription_user_id",
+        "TOPICOBJ": "topic_object",
+        "TOPICSTR": "topic_string",
+        "USERDATA": "user_data",
+        "VARUSER": "variable_user",
+        "WSCHEMA": "wildcard_schema"
+      },
+      "response_value_map": {}
+    },
+    "svstatus": {
+      "request_key_map": {},
+      "request_value_map": {},
+      "response_key_map": {
+        "CONTROL": "start_mode",
+        "DESCR": "description",
+        "PID": "process_id",
+        "SERVTYPE": "service_type",
+        "STARTARG": "start_arguments",
+        "STARTCMD": "start_command",
+        "STARTDA": "start_date",
+        "STARTTI": "start_time",
+        "STATUS": "status",
+        "STDERR": "stderr_destination",
+        "STDOUT": "stdout_destination",
+        "STOPARG": "stop_arguments",
+        "STOPCMD": "stop_command"
+      },
+      "response_value_map": {}
+    },
+    "tcluster": {
+      "request_key_map": {},
+      "request_value_map": {},
+      "response_key_map": {},
+      "response_value_map": {}
+    },
+    "thread": {
+      "request_key_map": {},
+      "request_value_map": {},
+      "response_key_map": {},
+      "response_value_map": {}
+    },
+    "topic": {
+      "request_key_map": {
+        "authorization_record": "AUTHREC",
+        "cap_expiry": "CAPEXPRY",
+        "cluster_name": "CLUSTER",
+        "cluster_publish_route": "CLROUTE",
+        "communication_info": "COMMINFO",
+        "command_scope": "CMDSCOPE",
+        "custom": "CUSTOM",
+        "default_persistence": "DEFPSIST",
+        "default_priority": "DEFPRTY",
+        "default_put_response": "DEFPRESP",
+        "description": "DESCR",
+        "durable_model_queue_name": "MDURMDL",
+        "durable_subscriptions": "DURSUB",
+        "ignore_state": "IGNSTATE",
+        "like": "LIKE",
+        "multicast": "MCAST",
+        "non_durable_model_queue_name": "MNDURMDL",
+        "non_persistent_message_delivery": "NPMSGDLV",
+        "persistent_message_delivery": "PMSGDLV",
+        "proxy_subscriptions": "PROXYSUB",
+        "publication_scope": "PUBSCOPE",
+        "queue_sharing_group_disposition": "QSGDISP",
+        "subscription_scope": "SUBSCOPE",
+        "topic_string": "TOPICSTR",
+        "topic_type": "TYPE",
+        "use_dead_letter_queue": "USEDLQ",
+        "wildcard_operation": "WILDCARD"
+      },
+      "request_key_value_map": {
+        "noreplace": {
+          "yes": {
+            "key": "REPLACE",
+            "value": "NO"
+          }
+        },
+        "replace": {
+          "no": {
+            "key": "REPLACE",
+            "value": "NO"
+          },
+          "yes": {
+            "key": "REPLACE",
+            "value": "YES"
+          }
+        }
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "ALTDATE": "alteration_date",
+        "ALTTIME": "alteration_time",
+        "CAPEXPRY": "cap_expiry",
+        "CLROUTE": "cluster_publish_route",
+        "CLSTATE": "cluster_object_state",
+        "CLUSTER": "cluster_name",
+        "COMMINFO": "communication_info",
+        "CUSTOM": "custom",
+        "DEFPRESP": "default_put_response",
+        "DEFPRTY": "default_priority",
+        "DEFPSIST": "default_persistence",
+        "DESCR": "description",
+        "DURSUB": "durable_subscriptions",
+        "MCAST": "multicast",
+        "MDURMDL": "durable_model_queue_name",
+        "MNDURMDL": "non_durable_model_queue_name",
+        "NPMSGDLV": "non_persistent_message_delivery",
+        "PMSGDLV": "persistent_message_delivery",
+        "PROXYSUB": "proxy_subscriptions",
+        "PUB": "publish",
+        "PUBSCOPE": "publication_scope",
+        "SUB": "subscribe",
+        "SUBSCOPE": "subscription_scope",
+        "TOPIC": "topic_name",
+        "TOPICSTR": "topic_string",
+        "TYPE": "topic_type",
+        "USEDLQ": "use_dead_letter_queue",
+        "WILDCARD": "wildcard_operation"
+      },
+      "response_value_map": {}
+    },
+    "topicstr": {
+      "request_key_map": {
+        "clear_type": "CLRTYPE",
+        "command_scope": "CMDSCOPE",
+        "scope": "SCOPE"
+      },
+      "request_value_map": {},
+      "response_key_map": {},
+      "response_value_map": {}
+    },
+    "tpipe": {
+      "request_key_map": {},
+      "request_value_map": {},
+      "response_key_map": {},
+      "response_value_map": {}
+    },
+    "tpstatus": {
+      "request_key_map": {
+        "command_scope": "CMDSCOPE",
+        "status_type": "TYPE"
+      },
+      "request_value_map": {},
+      "response_key_map": {
+        "ACTCONN": "active_connection",
+        "ADMIN": "admin_topic_name",
+        "CAPEXPRY": "cap_expiry",
+        "CLROUTE": "cluster_publish_route",
+        "CLUSTER": "cluster_name",
+        "COMMINFO": "communication_info",
+        "DEFPRESP": "default_put_response",
+        "DEFPRTY": "default_priority",
+        "DEFPSIST": "default_persistence",
+        "DURABLE": "durable",
+        "DURSUB": "durable_subscriptions",
+        "LMSGDATE": "last_message_date",
+        "LMSGTIME": "last_message_time",
+        "LPUBDATE": "last_publication_date",
+        "LPUBTIME": "last_publication_time",
+        "MCAST": "multicast",
+        "MCASTREL": "multicast_reliability_indicator",
+        "MDURMDL": "durable_model_queue_name",
+        "MNDURMDL": "non_durable_model_queue_name",
+        "NPMSGDLV": "non_persistent_message_delivery",
+        "NUMMSGS": "number_of_messages",
+        "NUMPUBS": "number_of_publishes",
+        "PMSGDLV": "persistent_message_delivery",
+        "PUBCOUNT": "publish_count",
+        "PUBSCOPE": "publication_scope",
+        "RESMDATE": "resume_date",
+        "RESMTIME": "resume_time",
+        "RETAINED": "retained_publication",
+        "SUBCOUNT": "subscription_count",
+        "SUBID": "subscription_id",
+        "SUBTYPE": "subscription_type",
+        "SUBUSER": "subscription_user_id",
+        "USEDLQ": "use_dead_letter_queue"
+      },
+      "response_value_map": {}
+    },
+    "trace": {
+      "request_key_map": {},
+      "request_value_map": {},
+      "response_key_map": {},
+      "response_value_map": {}
+    },
+    "usage": {
+      "request_key_map": {
+        "command_scope": "CMDSCOPE",
+        "page_set_id": "PSID",
+        "usage_type": "TYPE"
+      },
+      "request_value_map": {},
+      "response_key_map": {},
+      "response_value_map": {}
+    }
+  },
+  "version": 1
+}


### PR DESCRIPTION
# Pull Request

## Summary

- Add standard repository scaffolding to align with sibling mq-rest-admin-{java,python,go} repos
- Introduce AGENTS.md, CLAUDE.md, .gitignore, .markdownlint.json, GitHub issue/PR templates, docs standards, and canonical mapping-data.json

## Issue Linkage

- Fixes #12
- Work is not complete until the issue is closed.

## Testing

- markdownlint

Docs-only: tests skipped

Files changed:
- `AGENTS.md` — agent guidance (matches sibling repo pattern)
- `CLAUDE.md` — Claude Code guidance (adapted for documentation-only repo)
- `.gitignore` — editor/OS artifacts only
- `.markdownlint.json` — identical to sibling repos
- `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues
- `.github/ISSUE_TEMPLATE/issue.yml` — standard issue template
- `.github/pull_request_template.md` — adapted for markdownlint-only testing
- `docs/standards-and-conventions.md` — canonical standards reference
- `docs/repository-standards.md` — adapted for documentation repo type
- `mapping-data.json` — copied from Go repo as canonical source (byte-identical)

## Notes

- Markdownlint errors in AGENTS.md and CLAUDE.md match the same patterns present in the Java sibling repo (MD032/MD034) — these are established conventions across the project family
- mapping-data.json is byte-identical to the Go repo source