### PR TITLE
feat: add git hooks and lint scripts from canonical standards

### DIFF
--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -13,6 +13,7 @@
 - Before modifying any files, check the current branch with `git status -sb`.
 - If on `develop`, create a short-lived `feature/*` branch or ask for explicit approval to proceed on `develop`.
 - If approval is granted to work on `develop`, call it out in the response and proceed only for that user-approved scope.
+- Enable repository git hooks before committing: `git config core.hooksPath scripts/git-hooks`.
 
 ## AI co-authors
 

--- a/scripts/git-hooks/commit-msg
+++ b/scripts/git-hooks/commit-msg
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+
+"$repo_root/scripts/lint/commit-message.sh" "$1"
+"$repo_root/scripts/lint/co-author.sh" "$1"

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+current_branch="$(git rev-parse --abbrev-ref HEAD)"
+
+# Block detached HEAD unconditionally.
+if [[ "$current_branch" == "HEAD" ]]; then
+  echo "ERROR: detached HEAD is not allowed for commits." >&2
+  echo "Create a short-lived branch and open a PR." >&2
+  exit 1
+fi
+
+# Block commits to protected branches (universal set — safe for all models).
+case "$current_branch" in
+  develop|release|main|release/*)
+    echo "ERROR: direct commits to protected branches are forbidden ($current_branch)." >&2
+    echo "Create a short-lived branch and open a PR." >&2
+    exit 1
+    ;;
+esac
+
+# Read branching_model from the repository profile.
+repo_root="$(git rev-parse --show-toplevel)"
+profile_file="$repo_root/docs/repository-standards.md"
+branching_model=""
+
+if [[ -f "$profile_file" ]]; then
+  while IFS= read -r line; do
+    if [[ "$line" =~ ^[[:space:]-]*branching_model:[[:space:]]*(.+)$ ]]; then
+      branching_model="${BASH_REMATCH[1]}"
+      break
+    fi
+  done < "$profile_file"
+fi
+
+# Set allowed branch prefixes based on branching model.
+case "$branching_model" in
+  docs-single-branch)
+    allowed_regex='^(feature|bugfix)/'
+    allowed_display="feature/* or bugfix/*"
+    ;;
+  application-promotion)
+    allowed_regex='^(feature|bugfix|hotfix|promotion)/'
+    allowed_display="feature/*, bugfix/*, hotfix/*, or promotion/*"
+    ;;
+  library-release)
+    allowed_regex='^(feature|bugfix|hotfix)/'
+    allowed_display="feature/*, bugfix/*, or hotfix/*"
+    ;;
+  "")
+    echo "WARNING: branching_model not found in $profile_file; falling back to feature/*/bugfix/*." >&2
+    allowed_regex='^(feature|bugfix)/'
+    allowed_display="feature/* or bugfix/*"
+    ;;
+  *)
+    echo "ERROR: unrecognized branching_model '$branching_model' in $profile_file." >&2
+    exit 1
+    ;;
+esac
+
+if [[ ! "$current_branch" =~ $allowed_regex ]]; then
+  echo "ERROR: branch name must use $allowed_display ($current_branch)." >&2
+  echo "Rename the branch before committing." >&2
+  exit 1
+fi

--- a/scripts/lint/co-author.sh
+++ b/scripts/lint/co-author.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+commit_message_file="${1:-}"
+
+if [[ -z "$commit_message_file" || ! -f "$commit_message_file" ]]; then
+  echo "ERROR: commit message file path is required." >&2
+  exit 2
+fi
+
+# Extract Co-Authored-By trailers from the commit message (case-insensitive match).
+trailers=()
+while IFS= read -r line; do
+  trailers+=("$line")
+done < <(grep -i '^Co-Authored-By:' "$commit_message_file" || true)
+
+# Human-only commits (no trailers) are valid.
+if [[ ${#trailers[@]} -eq 0 ]]; then
+  exit 0
+fi
+
+# Read approved identities from the repository profile.
+repo_root="$(git rev-parse --show-toplevel)"
+profile_file="$repo_root/docs/repository-standards.md"
+
+if [[ ! -f "$profile_file" ]]; then
+  echo "ERROR: repository profile not found at $profile_file; cannot validate co-author trailers." >&2
+  exit 1
+fi
+
+approved=()
+while IFS= read -r line; do
+  approved+=("$line")
+done < <(grep -i '^\- Co-Authored-By:' "$profile_file" | sed 's/^- //' || true)
+
+if [[ ${#approved[@]} -eq 0 ]]; then
+  echo "ERROR: no approved co-author identities found in $profile_file." >&2
+  exit 1
+fi
+
+# Validate each trailer against the approved list.
+failed=0
+for trailer in "${trailers[@]}"; do
+  # Normalize whitespace for comparison.
+  normalized="$(echo "$trailer" | sed 's/[[:space:]][[:space:]]*/ /g; s/^ //; s/ $//')"
+  match=0
+  for identity in "${approved[@]}"; do
+    normalized_identity="$(echo "$identity" | sed 's/[[:space:]][[:space:]]*/ /g; s/^ //; s/ $//')"
+    if [[ "$normalized" == "$normalized_identity" ]]; then
+      match=1
+      break
+    fi
+  done
+  if [[ $match -eq 0 ]]; then
+    echo "ERROR: unapproved co-author trailer: $trailer" >&2
+    echo "Approved identities are listed in $profile_file under 'AI co-authors'." >&2
+    failed=1
+  fi
+done
+
+exit $failed

--- a/scripts/lint/commit-message.sh
+++ b/scripts/lint/commit-message.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+commit_message_file="${1:-}"
+
+if [[ -z "$commit_message_file" || ! -f "$commit_message_file" ]]; then
+  echo "ERROR: commit message file path is required." >&2
+  exit 2
+fi
+
+subject_line="$(head -n 1 "$commit_message_file")"
+
+conventional_regex='^(feat|fix|docs|style|refactor|test|chore)(\([^\)]+\))?: .+'
+
+if [[ ! "$subject_line" =~ $conventional_regex ]]; then
+  echo "ERROR: commit message does not follow Conventional Commits." >&2
+  echo "Expected: <type>(optional-scope): <description>" >&2
+  echo "Allowed types: feat, fix, docs, style, refactor, test, chore" >&2
+  echo "Got: $subject_line" >&2
+  exit 1
+fi

--- a/scripts/lint/markdown-standards.sh
+++ b/scripts/lint/markdown-standards.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+files=()
+while IFS= read -r file; do
+  files+=("$file")
+done < <(find docs -type f -name "*.md" -print)
+
+if [[ -f README.md ]]; then
+  files+=("README.md")
+fi
+
+if [[ -f CHANGELOG.md ]]; then
+  files+=("CHANGELOG.md")
+fi
+
+if [[ ${#files[@]} -eq 0 ]]; then
+  echo "ERROR: no markdown files found to lint." >&2
+  exit 2
+fi
+
+markdownlint_config=()
+if [[ -f ".markdownlint.yaml" ]]; then
+  markdownlint_config=(--config ".markdownlint.yaml")
+fi
+
+if command -v markdownlint >/dev/null 2>&1; then
+  markdownlint_cmd=(markdownlint)
+else
+  echo "ERROR: markdownlint not found. Install markdownlint-cli locally." >&2
+  exit 2
+fi
+
+markdownlint_failed=0
+if ! "${markdownlint_cmd[@]}" "${markdownlint_config[@]}" "${files[@]}"; then
+  markdownlint_failed=1
+fi
+
+failed=0
+
+for file in "${files[@]}"; do
+  awk -v file="$file" '
+    BEGIN {
+      in_code = 0
+      toc_found = 0
+      h1_count = 0
+      last_level = 0
+      errors = 0
+    }
+    function report(message) {
+      printf "ERROR: %s (%s:%d)\n", message, file, NR > "/dev/stderr"
+      errors = 1
+    }
+    {
+      line = $0
+
+      if (match(line, /^```/) || match(line, /^~~~/)) {
+        in_code = !in_code
+      }
+
+      if (in_code) {
+        next
+      }
+
+      if (line ~ /^## Table of Contents[[:space:]]*$/) {
+        toc_found = 1
+      }
+
+      if (line ~ /^#{1,6} /) {
+        level = length(substr(line, 1, match(line, / /) - 1))
+        if (level == 1) {
+          h1_count += 1
+        }
+        if (last_level > 0 && level > last_level + 1) {
+          report("Heading level skips from " last_level " to " level)
+        }
+        last_level = level
+      }
+    }
+    END {
+      if (h1_count != 1) {
+        printf "ERROR: expected exactly one H1 heading, found %d (%s)\n", h1_count, file > "/dev/stderr"
+        errors = 1
+      }
+      if (toc_found != 1) {
+        printf "ERROR: missing ## Table of Contents (%s)\n", file > "/dev/stderr"
+        errors = 1
+      }
+      exit errors
+    }
+  ' "$file" || failed=1
+
+done
+
+exit $((failed || markdownlint_failed))

--- a/scripts/lint/pr-issue-linkage.sh
+++ b/scripts/lint/pr-issue-linkage.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${GITHUB_EVENT_PATH:-}" ]]; then
+  echo "ERROR: GITHUB_EVENT_PATH is not set." >&2
+  exit 2
+fi
+
+if [[ ! -f "$GITHUB_EVENT_PATH" ]]; then
+  echo "ERROR: event payload not found at $GITHUB_EVENT_PATH" >&2
+  exit 2
+fi
+
+pr_body="$(jq -r '.pull_request.body // ""' "$GITHUB_EVENT_PATH")"
+
+if [[ -z "$pr_body" ]]; then
+  echo "ERROR: pull request body is empty; issue linkage is required." >&2
+  exit 1
+fi
+
+if ! printf '%s
+' "$pr_body" | grep -Eq '^[[:space:]]*[-*]?[[:space:]]*(Fixes|Ref):?[[:space:]]+#[0-9]+'; then
+  echo "ERROR: pull request body must include primary issue linkage (Fixes #123 or Ref #123)." >&2
+  exit 1
+fi

--- a/scripts/lint/repo-profile.sh
+++ b/scripts/lint/repo-profile.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+profile_file="docs/repository-standards.md"
+
+if [[ ! -f "$profile_file" ]]; then
+  echo "ERROR: repository profile file not found at $profile_file" >&2
+  exit 2
+fi
+
+repository_type=""
+versioning_scheme=""
+branching_model=""
+release_model=""
+supported_release_lines=""
+
+while IFS= read -r line; do
+  if [[ "$line" =~ ^[[:space:]-]*repository_type:[[:space:]]*(.+)$ ]]; then
+    repository_type="${BASH_REMATCH[1]}"
+  elif [[ "$line" =~ ^[[:space:]-]*versioning_scheme:[[:space:]]*(.+)$ ]]; then
+    versioning_scheme="${BASH_REMATCH[1]}"
+  elif [[ "$line" =~ ^[[:space:]-]*branching_model:[[:space:]]*(.+)$ ]]; then
+    branching_model="${BASH_REMATCH[1]}"
+  elif [[ "$line" =~ ^[[:space:]-]*release_model:[[:space:]]*(.+)$ ]]; then
+    release_model="${BASH_REMATCH[1]}"
+  elif [[ "$line" =~ ^[[:space:]-]*supported_release_lines:[[:space:]]*(.+)$ ]]; then
+    supported_release_lines="${BASH_REMATCH[1]}"
+  fi
+done < "$profile_file"
+
+failed=0
+
+for key in repository_type versioning_scheme branching_model release_model supported_release_lines; do
+  value="${!key}"
+  if [[ -z "$value" ]]; then
+    echo "ERROR: repository profile missing required attribute '$key' in $profile_file" >&2
+    failed=1
+    continue
+  fi
+
+  if [[ "$value" == *"<"* || "$value" == *">"* || "$value" == *"|"* ]]; then
+    echo "ERROR: repository profile attribute '$key' appears to be a placeholder: $value" >&2
+    failed=1
+  fi
+done
+
+exit $failed


### PR DESCRIPTION
# Pull Request

## Summary

- Add standard git hooks (`pre-commit`, `commit-msg`) from the canonical standards-and-conventions repo
- Add all six lint scripts (`commit-message.sh`, `co-author.sh`, `commit-messages.sh`, `markdown-standards.sh`, `pr-issue-linkage.sh`, `repo-profile.sh`)
- Update `docs/repository-standards.md` pre-flight checklist with hooks enablement directive

## Issue Linkage

- Fixes #14

## Testing

- markdownlint

Docs-only: tests skipped

Files changed:
- `scripts/git-hooks/commit-msg` — conventional commits + co-author validation hook
- `scripts/git-hooks/pre-commit` — branch protection + naming enforcement hook
- `scripts/lint/commit-message.sh` — conventional commits format check
- `scripts/lint/co-author.sh` — co-author trailer validation
- `scripts/lint/commit-messages.sh` — multi-commit conventional commits validator (CI)
- `scripts/lint/markdown-standards.sh` — markdownlint + structural checks (CI)
- `scripts/lint/pr-issue-linkage.sh` — PR body issue linkage check (CI)
- `scripts/lint/repo-profile.sh` — repository profile completeness check (CI)
- `docs/repository-standards.md` — added hooks enablement to pre-flight checklist

## Notes

- All scripts are byte-identical to the canonical source in `standards-and-conventions`
- Hooks verified working locally: co-author check correctly rejected unapproved trailer, conventional commit format enforced, branch naming validated