### PR TITLE
feat: bootstrap MkDocs site and GitHub Pages workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,55 @@
+name: Docs - Build and Deploy
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install MkDocs
+        run: pip install mkdocs-material
+
+      - name: Build MkDocs site
+        run: mkdocs build -f docs/site/mkdocs.yml --strict
+
+      - name: Upload pages artifact
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/site/site
+
+  deploy:
+    name: deploy
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 # Cursor
 .cursorignore
 .cursorindexingignore
+
+# Documentation
+docs/site/site/

--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -1,0 +1,19 @@
+# mq-rest-admin-common
+
+Shared documentation fragments and canonical mapping data for the
+mq-rest-admin project family.
+
+## What this repository provides
+
+- **Documentation fragments** — language-neutral explanations of architecture,
+  mapping pipeline, design decisions, and high-level patterns (ensure, sync)
+  that are composed into per-language documentation sites.
+- **Canonical mapping data** — the single source of truth for
+  `mapping-data.json`, which defines the bidirectional attribute mappings
+  between developer-friendly names and native MQSC parameters.
+
+## Consuming repositories
+
+- [mq-rest-admin-java](https://github.com/wphillipmoore/mq-rest-admin-java) — Java
+- [mq-rest-admin-python](https://github.com/wphillipmoore/mq-rest-admin-python) — Python
+- [mq-rest-admin-go](https://github.com/wphillipmoore/mq-rest-admin-go) — Go

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -1,0 +1,55 @@
+site_name: mq-rest-admin-common
+site_url: https://wphillipmoore.github.io/mq-rest-admin-common/
+site_description: Shared documentation fragments and canonical mapping data for the mq-rest-admin project family
+repo_url: https://github.com/wphillipmoore/mq-rest-admin-common
+repo_name: mq-rest-admin-common
+edit_uri: ""
+
+strict: true
+
+docs_dir: docs
+
+theme:
+  name: material
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - content.code.copy
+    - search.highlight
+    - search.suggest
+  palette:
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+
+plugins:
+  - search
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.snippets:
+      base_path:
+        - docs
+        - ../../fragments
+  - tables
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md


### PR DESCRIPTION
# Pull Request

## Summary

- Add MkDocs + Material site scaffold (`docs/site/mkdocs.yml`, `docs/site/docs/index.md`)
- Add GitHub Actions workflow for building and deploying to GitHub Pages
- Update `.gitignore` to exclude built site output

## Issue Linkage

- Fixes #16

## Testing

- markdownlint
- `mkdocs build -f docs/site/mkdocs.yml --strict` succeeds locally

Docs-only: tests skipped

Files changed:
- `docs/site/mkdocs.yml` — MkDocs configuration with Material theme, matching sibling repos
- `docs/site/docs/index.md` — Placeholder landing page
- `.github/workflows/docs.yml` — Build and deploy workflow (Go repo pattern)
- `.gitignore` — Added `docs/site/site/`

## Notes

- Site builds cleanly with `--strict` mode
- Snippets base_path points to `../../fragments` (local, no external checkout needed)
- Workflow triggers on push to `main` and `workflow_dispatch`
- Nav starts minimal (Home only) — will be expanded as content is added