### PR TITLE
fix: run mike from repo root and add language libraries page

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,10 +53,9 @@ jobs:
           fi
 
       - name: Deploy docs
-        working-directory: docs/site
         run: |
           if [ -n "${{ steps.version.outputs.alias }}" ]; then
-            mike deploy --push --update-aliases ${{ steps.version.outputs.version }} ${{ steps.version.outputs.alias }}
+            mike deploy -F docs/site/mkdocs.yml --push --update-aliases ${{ steps.version.outputs.version }} ${{ steps.version.outputs.alias }}
           else
-            mike deploy --push ${{ steps.version.outputs.version }}
+            mike deploy -F docs/site/mkdocs.yml --push ${{ steps.version.outputs.version }}
           fi

--- a/docs/site/docs/languages.md
+++ b/docs/site/docs/languages.md
@@ -1,0 +1,35 @@
+# Language Libraries
+
+The mq-rest-admin project provides implementations in three languages.
+Each library wraps the IBM MQ administrative REST API with the same
+design — qualifier-based attribute mapping, method-per-command API,
+and shared `mapping-data.json` — adapted to idiomatic conventions
+for its language.
+
+## Java
+
+**Repository**: [mq-rest-admin-java](https://github.com/wphillipmoore/mq-rest-admin-java)
+| **Documentation**: [wphillipmoore.github.io/mq-rest-admin-java](https://wphillipmoore.github.io/mq-rest-admin-java/)
+
+- Maven coordinates: `io.github.wphillipmoore:mq-rest-admin`
+- Zero runtime dependencies beyond Gson
+- `java.net.http.HttpClient` transport
+- camelCase method names (`displayQueue()`, `defineQlocal()`)
+
+## Python
+
+**Repository**: [mq-rest-admin-python](https://github.com/wphillipmoore/mq-rest-admin-python)
+| **Documentation**: [wphillipmoore.github.io/mq-rest-admin-python](https://wphillipmoore.github.io/mq-rest-admin-python/)
+
+- PyPI package: `pymqrest`
+- `httpx` transport with async support
+- snake_case method names (`display_queue()`, `define_qlocal()`)
+
+## Go
+
+**Repository**: [mq-rest-admin-go](https://github.com/wphillipmoore/mq-rest-admin-go)
+| **Documentation**: [wphillipmoore.github.io/mq-rest-admin-go](https://wphillipmoore.github.io/mq-rest-admin-go/)
+
+- Zero external dependencies (Go standard library only)
+- `context.Context` integration for all I/O methods
+- PascalCase method names (`DisplayQueue()`, `DefineQlocal()`)

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -108,7 +108,4 @@ nav:
   - Development:
       - Local MQ Container: development/local-mq-container.md
   - AI Engineering: ai-engineering.md
-  - Language Libraries:
-      - Java: https://wphillipmoore.github.io/mq-rest-admin-java/
-      - Python: https://wphillipmoore.github.io/mq-rest-admin-python/
-      - Go: https://wphillipmoore.github.io/mq-rest-admin-go/
+  - Language Libraries: languages.md


### PR DESCRIPTION
## Summary

- Remove `working-directory: docs/site` from mike deploy step so CWD is the repo root, matching the `base_path` entries in mkdocs.yml — fixes fragment includes not resolving in CI
- Replace Language Libraries external links with a dedicated page describing each implementation

Ref #32

## Test plan

- [x] `mkdocs build -f docs/site/mkdocs.yml --strict` passes
- [ ] Deployed site shows AI Engineering fragment content
- [ ] Language Libraries page shows descriptions with links

🤖 Generated with [Claude Code](https://claude.com/claude-code)