### PR TITLE
docs: expand QA guardrails and add quality gates reference

### DIFF
--- a/docs/site/docs/development/quality-gates.md
+++ b/docs/site/docs/development/quality-gates.md
@@ -1,0 +1,3 @@
+# Quality gates
+
+--8<-- "development/quality-gates.md"

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -107,5 +107,6 @@ nav:
       - usage: mappings/usage.md
   - Development:
       - Local MQ Container: development/local-mq-container.md
+      - Quality Gates: development/quality-gates.md
   - AI Engineering: ai-engineering.md
   - Language Libraries: languages.md

--- a/fragments/ai-engineering.md
+++ b/fragments/ai-engineering.md
@@ -51,20 +51,88 @@ patterns were human decisions refined through discussion.
 
 ## Quality assurance
 
-The AI-assisted development process maintains quality through:
+AI-generated code is held to the same standards as human-written code.
+Every guardrail listed below is enforced as a CI hard gate — pull
+requests that violate any check cannot merge.
 
-**Test coverage**: All production code is covered by unit tests. Coverage
-is enforced as a CI hard gate in each language implementation.
+### Test coverage
 
-**Static analysis**: Each implementation runs language-appropriate linters
-and static analysis tools as CI hard gates.
+All production code is covered by unit tests with 100% line and branch
+coverage enforced at the CI level. Coverage is measured per-build and
+any drop below 100% fails the pipeline. Each language uses its
+ecosystem's standard coverage tool (JaCoCo, pytest-cov, go tool cover).
 
-**Validation pipeline**: Each repository provides a single command that runs
-the same checks as CI, including formatting, linting, tests, and coverage.
+### Static analysis and linting
 
-**Integration testing**: Containerized IBM MQ queue managers provide real
-MQSC command validation. Integration tests verify that mapping assumptions
-hold against actual MQ responses.
+Each implementation runs language-appropriate linters and static analysis
+tools as CI hard gates:
+
+- **Formatting**: Automatic formatting enforcement ensures consistent
+  style regardless of author (human or AI). Formatting is checked, not
+  just applied, so unformatted code fails CI.
+- **Lint rules**: Comprehensive lint rulesets catch code smells, unused
+  imports, naming violations, and anti-patterns.
+- **Bug analysis**: Static analysis tools detect potential bugs, null
+  pointer risks, concurrency issues, and security vulnerabilities.
+- **Type checking**: Where applicable, strict type checking ensures type
+  safety across the entire source tree.
+
+### Security scanning
+
+- **CodeQL**: GitHub's semantic code analysis runs on every pull request,
+  detecting injection flaws, insecure data handling, and other
+  vulnerability classes.
+- **Dependency auditing**: Every build audits runtime dependencies for
+  known CVEs. Vulnerable dependencies fail the pipeline.
+- **License compliance**: Dependency licenses are checked against an
+  allow-list of approved open-source licenses. Unapproved licenses
+  fail the build.
+
+### Validation pipeline
+
+Each repository provides a single command that runs the same checks as
+CI — formatting, linting, type checking, tests, coverage enforcement,
+and static analysis. This ensures developers (human and AI) can verify
+changes locally before pushing.
+
+### Integration testing
+
+Containerized IBM MQ queue managers provide real MQSC command validation.
+Integration tests verify that mapping assumptions hold against actual MQ
+responses, catching mismatches between the mapping data and real queue
+manager behavior.
+
+### Git hooks
+
+Local git hooks enforce standards before code reaches CI:
+
+- **Conventional Commits**: The `commit-msg` hook validates that every
+  commit message follows the `type(scope): description` format.
+- **Co-author validation**: The `commit-msg` hook checks that
+  `Co-Authored-By` trailers match the repository's approved identity
+  list — unapproved AI identities are rejected.
+- **Branch protection**: The `pre-commit` hook blocks commits to
+  protected branches (`main`, `develop`, `release/*`) and enforces
+  the repository's branching model naming convention.
+
+### CI gate structure
+
+Pull requests must pass all of the following independent CI jobs before
+merging:
+
+1. **standards-compliance** — Conventional Commit format, co-author
+   validation, PR issue linkage, markdown standards, repository profile
+2. **dependency-audit** — Vulnerability scanning and license compliance
+3. **release-gates** — Version format and divergence checks for
+   release-targeting PRs
+4. **test-and-validate** — Full validation pipeline across multiple
+   language/runtime versions
+5. **codeql** — GitHub semantic security analysis
+6. **integration-tests** — End-to-end tests against containerized MQ
+
+A **docs-only** detection job allows documentation changes to skip
+test-and-validate, CodeQL, and integration tests while still requiring
+standards compliance and dependency audit.
 
 ## The `Co-Authored-By` convention
 

--- a/fragments/development/quality-gates.md
+++ b/fragments/development/quality-gates.md
@@ -1,0 +1,157 @@
+## Overview
+
+Every mq-rest-admin repository enforces a layered quality gate system.
+Local git hooks catch issues before code leaves the developer's machine,
+and CI pipelines enforce the same standards (plus additional checks) on
+every pull request. Pull requests cannot merge until all required jobs
+pass.
+
+## Git hooks
+
+Git hooks are stored in `scripts/git-hooks/` and activated with:
+
+```bash
+git config core.hooksPath scripts/git-hooks
+```
+
+### pre-commit
+
+The `pre-commit` hook runs before each commit and enforces:
+
+**Protected branch blocking** — Commits directly to `main`, `develop`,
+`release/*`, or a detached HEAD are rejected. All work must go through
+short-lived feature branches and pull requests.
+
+**Branch naming enforcement** — The hook reads the `branching_model`
+attribute from `docs/repository-standards.md` and enforces the
+corresponding naming convention:
+
+| Branching model | Allowed prefixes |
+|---|---|
+| `docs-single-branch` | `feature/*`, `bugfix/*` |
+| `library-release` | `feature/*`, `bugfix/*`, `hotfix/*` |
+| `application-promotion` | `feature/*`, `bugfix/*`, `hotfix/*`, `promotion/*` |
+
+### commit-msg
+
+The `commit-msg` hook runs after the commit message is written and
+validates two things:
+
+**Conventional Commits format** — The subject line must match:
+
+```
+<type>(optional-scope): <description>
+```
+
+Allowed types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`.
+
+**Co-author identity validation** — If the commit includes
+`Co-Authored-By` trailers, each trailer is checked against the approved
+identity list in `docs/repository-standards.md`. Unapproved identities
+are rejected. Commits without co-author trailers (human-only commits)
+are always valid.
+
+## CI pipeline
+
+The CI pipeline (`ci.yml`) runs on every pull request and on pushes to
+`develop` and `release/**`. It consists of several independent jobs, all
+of which must pass for a PR to merge.
+
+### docs-only detection
+
+A preliminary job detects whether the changeset is docs-only (as defined
+by the repository). When docs-only is detected, the test-intensive jobs
+(test-and-validate, CodeQL, integration tests) are skipped, while
+standards-compliance and dependency-audit still run.
+
+### standards-compliance
+
+Validates repository standards using a shared composite action:
+
+- **Conventional Commits** — All commits in the PR are validated against
+  the `type(scope): description` format.
+- **Co-author trailers** — All `Co-Authored-By` trailers are checked
+  against the approved list.
+- **PR issue linkage** — The PR body must include `Fixes #N` or `Ref #N`
+  linking to a tracking issue. Other GitHub keywords (`Closes`,
+  `Resolves`) are rejected.
+- **Markdown standards** — Documentation files are checked for exactly
+  one H1, no heading level skips, presence of a `## Table of Contents`
+  section, and markdownlint compliance.
+- **Repository profile** — The `docs/repository-standards.md` file is
+  validated for required attributes: `repository_type`,
+  `versioning_scheme`, `branching_model`, `release_model`, and
+  `supported_release_lines`.
+
+### dependency-audit
+
+Audits runtime dependencies for security vulnerabilities and license
+compliance:
+
+| Language | Vulnerability scanner | License checker |
+|---|---|---|
+| Java | `mvn dependency:tree` (resolution verification) | `license-maven-plugin` with allow-list |
+| Python | `pip-audit` against requirements files | `pip-licenses` with allow-list |
+| Go | `govulncheck ./...` | `go-licenses check` with allow-list |
+
+Allowed licenses: Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause, ISC,
+MPL-2.0, GPL-3.0-or-later, and PSF-2.0.
+
+### release-gates
+
+Validates version metadata on PRs targeting protected branches:
+
+**PRs targeting main** (release PRs):
+
+- Version must be plain semver (`x.y.z`) with no pre-release suffix
+- Version must not already exist on the package registry
+- Changelog must include an entry for the release version
+
+**PRs targeting develop**:
+
+- Version must differ from the version on `main`, preventing accidental
+  version collisions
+
+### test-and-validate
+
+Runs the full validation pipeline across a matrix of language/runtime
+versions:
+
+| Language | Versions tested | Validation command |
+|---|---|---|
+| Java | 17, 21, 25-ea | `./mvnw verify` |
+| Python | 3.12, 3.13, 3.14 | ruff + mypy + ty + pytest |
+| Go | 1.25, 1.26 | go vet + golangci-lint + go test |
+
+The validation pipeline includes (in order):
+
+1. **Formatting check** — Unformatted code fails the build
+2. **Lint and style checks** — Code smell and style rule enforcement
+3. **Type checking** — Strict type analysis (where applicable)
+4. **Unit tests** — Full test suite execution
+5. **Coverage enforcement** — 100% line and branch coverage required
+6. **Static analysis** — Bug pattern and vulnerability detection
+
+### CodeQL
+
+GitHub's semantic code analysis runs on every non-docs PR. It detects
+injection flaws, insecure data handling, and other vulnerability classes
+specific to each language.
+
+### integration-tests
+
+End-to-end tests run against containerized IBM MQ queue managers
+provisioned by the `mq-dev-environment` repository. These tests issue
+real MQSC commands through the REST API and verify that:
+
+- Mapping data correctly translates between friendly names and MQ
+  attribute names
+- Command methods produce valid REST API requests
+- Response parsing handles real MQ response structures
+
+## Documentation deployment
+
+A separate `docs.yml` workflow deploys documentation on pushes to `main`
+and `develop` using mike for versioned deployment. Pushes to `develop`
+deploy the `dev` version; pushes to `main` deploy a numbered version
+(read from `VERSION` or the package metadata) with a `latest` alias.


### PR DESCRIPTION
# Pull Request

## Summary

- Expand the Quality Assurance section in `fragments/ai-engineering.md` with detailed guardrails covering test coverage enforcement, static analysis, security scanning (CodeQL, dependency auditing, license compliance), git hooks, and CI gate structure
- Add new `fragments/development/quality-gates.md` fragment documenting the complete set of git hooks (pre-commit branch protection, commit-msg conventional commits and co-author validation) and all CI pipeline jobs (standards-compliance, dependency-audit, release-gates, test-and-validate, CodeQL, integration-tests)
- Add quality gates page to the docs site nav

## Issue Linkage

- Fixes #35
- Fixes #36

## Testing

- `mkdocs build -f docs/site/mkdocs.yml --strict` passes
- Docs-only: tests skipped

## Notes

- The expanded AI engineering fragment is consumed by all 3 language repos via `--8<-- "ai-engineering.md"` includes — no language repo changes needed
- The quality gates fragment is language-neutral; language repos can optionally add appendages later
- Files changed: `fragments/ai-engineering.md`, `fragments/development/quality-gates.md`, `docs/site/docs/development/quality-gates.md`, `docs/site/mkdocs.yml`