### PR TITLE
docs: add Trivy and Semgrep to quality gates documentation

### DIFF
--- a/fragments/ai-engineering.md
+++ b/fragments/ai-engineering.md
@@ -81,9 +81,17 @@ tools as CI hard gates:
 
 - **CodeQL**: GitHub's semantic code analysis runs on every pull request,
   detecting injection flaws, insecure data handling, and other
-  vulnerability classes.
+  vulnerability classes via deep data flow and taint tracking.
+- **Semgrep**: Pattern-based SAST provides custom security rule coverage
+  across all languages, complementing CodeQL with broader language
+  support and project-specific rule authoring.
+- **Trivy**: Filesystem vulnerability scanning detects known CVEs in
+  dependencies, lock files, and configuration files across all
+  language ecosystems.
 - **Dependency auditing**: Every build audits runtime dependencies for
-  known CVEs. Vulnerable dependencies fail the pipeline.
+  known CVEs using language-native tools (pip-audit, govulncheck,
+  Maven dependency verification). Vulnerable dependencies fail the
+  pipeline.
 - **License compliance**: Dependency licenses are checked against an
   allow-list of approved open-source licenses. Unapproved licenses
   fail the build.
@@ -128,11 +136,13 @@ merging:
 4. **test-and-validate** — Full validation pipeline across multiple
    language/runtime versions
 5. **codeql** — GitHub semantic security analysis
-6. **integration-tests** — End-to-end tests against containerized MQ
+6. **trivy** — Filesystem vulnerability scanning across all ecosystems
+7. **semgrep** — Pattern-based SAST with language-specific rulesets
+8. **integration-tests** — End-to-end tests against containerized MQ
 
 A **docs-only** detection job allows documentation changes to skip
-test-and-validate, CodeQL, and integration tests while still requiring
-standards compliance and dependency audit.
+test-and-validate, CodeQL, Trivy, Semgrep, and integration tests while
+still requiring standards compliance and dependency audit.
 
 ## The `Co-Authored-By` convention
 

--- a/fragments/development/quality-gates.md
+++ b/fragments/development/quality-gates.md
@@ -61,8 +61,8 @@ of which must pass for a PR to merge.
 
 A preliminary job detects whether the changeset is docs-only (as defined
 by the repository). When docs-only is detected, the test-intensive jobs
-(test-and-validate, CodeQL, integration tests) are skipped, while
-standards-compliance and dependency-audit still run.
+(test-and-validate, CodeQL, Trivy, Semgrep, integration tests) are
+skipped, while standards-compliance and dependency-audit still run.
 
 ### standards-compliance
 
@@ -134,9 +134,25 @@ The validation pipeline includes (in order):
 
 ### CodeQL
 
-GitHub's semantic code analysis runs on every non-docs PR. It detects
-injection flaws, insecure data handling, and other vulnerability classes
-specific to each language.
+GitHub's semantic code analysis runs on every non-docs PR. CodeQL
+performs deep data flow and taint tracking analysis to detect injection
+flaws, insecure data handling, and other vulnerability classes specific
+to each language.
+
+### Trivy
+
+Aqua Security's Trivy runs a filesystem vulnerability scan on every
+non-docs PR. It detects known CVEs in dependencies, lock files, and
+configuration files across all language ecosystems, complementing the
+language-specific scanners in the dependency-audit job with broader
+cross-ecosystem coverage.
+
+### Semgrep
+
+Semgrep runs pattern-based Static Application Security Testing (SAST)
+on every non-docs PR. It complements CodeQL by providing broader
+language coverage and support for custom security rules. Each language
+repo configures Semgrep with language-specific rulesets.
 
 ### integration-tests
 


### PR DESCRIPTION
# Pull Request

## Summary

- Add Trivy (filesystem vulnerability scanning) and Semgrep (pattern-based SAST) to the AI engineering fragment's security scanning section and CI gate list
- Add dedicated Trivy and Semgrep sections to the quality gates fragment
- Update docs-only skip lists to include the new jobs
- CI gate count updated from 6 to 8 to match actual pipelines

## Issue Linkage

- Fixes #38
- Ref #11

## Testing

- mkdocs build -f docs/site/mkdocs.yml --strict passes
- Docs-only: tests skipped
- Files changed: fragments/ai-engineering.md, fragments/development/quality-gates.md

## Notes

- Language repos pick up the changes automatically via snippet includes — no language repo changes needed