### PR TITLE
fix: restore 4 missing mapping entries from Python source

### DIFF
--- a/mapping-data.json
+++ b/mapping-data.json
@@ -1191,13 +1191,16 @@
         "APPLDESC": "application_description",
         "APPLTAG": "application_tag",
         "APPLTYPE": "application_type",
+        "ASTATE": "asynchronous_state",
         "CHANNEL": "channel_name",
         "CLIENTID": "client_id",
+        "CONN": "connection_id",
         "CONNAME": "connection_name",
         "CONNOPTS": "connection_options",
         "CONNTAG": "connection_tag",
         "DEST": "destination",
         "DESTQMGR": "destination_queue_manager",
+        "EXTCONN": "connection_prefix",
         "EXTURID": "unit_of_work_id",
         "HSTATE": "handle_state",
         "OBJNAME": "object_name",
@@ -2088,7 +2091,8 @@
     },
     "qstatus": {
       "request_key_map": {
-        "command_scope": "CMDSCOPE"
+        "command_scope": "CMDSCOPE",
+        "type": "TYPE"
       },
       "request_value_map": {},
       "response_key_map": {


### PR DESCRIPTION
# Pull Request

## Summary

- Restore 4 mapping entries inadvertently dropped during initial extraction from Python source
- `conn.response_key_map`: `ASTATE → asynchronous_state`, `CONN → connection_id`, `EXTCONN → connection_prefix`
- `qstatus.request_key_map`: `type → TYPE`

## Issue Linkage

- Fixes #40

## Testing

- Docs-only: tests skipped
- Files changed: `mapping-data.json`
- JSON validated with `python3 -c "import json; json.load(open('mapping-data.json'))"`

## Notes

- All 4 entries existed in the original Python mapping data and were lost during conversion to canonical JSON