### PR TITLE
docs: add Ruby and Rust placeholders to language implementations

### DIFF
--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -30,3 +30,5 @@ mq-rest-admin project family.
 - [mq-rest-admin-java](https://github.com/wphillipmoore/mq-rest-admin-java) — Java
 - [mq-rest-admin-python](https://github.com/wphillipmoore/mq-rest-admin-python) — Python
 - [mq-rest-admin-go](https://github.com/wphillipmoore/mq-rest-admin-go) — Go
+- [mq-rest-admin-ruby](https://github.com/wphillipmoore/mq-rest-admin-ruby) — Ruby (Work in Progress)
+- [mq-rest-admin-rust](https://github.com/wphillipmoore/mq-rest-admin-rust) — Rust (Work in Progress)


### PR DESCRIPTION
# Pull Request

## Summary

- Add Ruby and Rust placeholder entries to the Language implementations section, marked as Work in Progress

## Issue Linkage

- Fixes #42

## Testing

- markdownlint
- `mkdocs build -f docs/site/mkdocs.yml --strict` succeeds

Docs-only: tests skipped

Files changed:
- `docs/site/docs/index.md` — added two list items for mq-rest-admin-ruby and mq-rest-admin-rust

## Notes

-