### PR TITLE
fix: set docs default version to latest on main deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,6 +56,7 @@ jobs:
         run: |
           if [ -n "${{ steps.version.outputs.alias }}" ]; then
             mike deploy -F docs/site/mkdocs.yml --push --update-aliases ${{ steps.version.outputs.version }} ${{ steps.version.outputs.alias }}
+            mike set-default -F docs/site/mkdocs.yml --push latest
           else
             mike deploy -F docs/site/mkdocs.yml --push ${{ steps.version.outputs.version }}
           fi


### PR DESCRIPTION
## Summary

- Add `mike set-default latest` after deploying from `main` so the root URL (`/mq-rest-admin-common/`) redirects to the latest release instead of `dev/`

## Root cause

The docs workflow used `mike deploy --update-aliases` to create the `latest` alias, but never called `mike set-default` to update the root `index.html` redirect. The first version deployed (`dev`) captured the default and it was never updated.

## Test plan

- [ ] Merge to `develop`, then merge `develop` → `main`
- [ ] Verify `https://wphillipmoore.github.io/mq-rest-admin-common/` redirects to `1.1/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)