### PR TITLE
docs: draft mq-rest-admin 1.1 multi-language announcement

### DIFF
--- a/docs/announcements/mq-rest-admin-1.1.md
+++ b/docs/announcements/mq-rest-admin-1.1.md
@@ -136,10 +136,10 @@ HTTPS.
 ### What's coming next
 
 Ruby and Rust ports are already under way &mdash; both repositories are
-public on GitHub. The shared architecture makes adding new languages
-straightforward: the mapping data, command coverage, and ensure
-semantics are defined once in the common repository and consumed by each
-language implementation.
+public on GitHub. Because every implementation shares the same API shape and semantics
+&mdash; the same command coverage, the same ensure behaviour, the same
+attribute mappings &mdash; adding a new language is primarily a matter
+of expressing those patterns idiomatically.
 
 If your language isn't covered yet, I'd genuinely like to hear about it.
 Open an issue on the


### PR DESCRIPTION
## Summary

- Draft three-tier announcement (short/medium/micro) for the mq-rest-admin 1.1 series
- Covers expansion from Python-only to Python, Java, and Go with shared mapping data
- Highlights upcoming Ruby and Rust ports
- Closes with call to action encouraging requests for additional language ports
- Modeled on the pymqrest 1.0.0 announcement format

Closes #48

## Test plan

- [x] `markdownlint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
