### PR TITLE
fix: correct Go package name in 1.1 announcement

### DIFF
--- a/docs/announcements/mq-rest-admin-1.1.md
+++ b/docs/announcements/mq-rest-admin-1.1.md
@@ -23,7 +23,7 @@ The 1.1 release brings Python, Java, and Go to feature parity:
 - **Java** (`mq-rest-admin`) &mdash; Maven Central. camelCase methods,
   `java.net.http.HttpClient` transport, zero runtime dependencies beyond
   Gson.
-- **Go** (`mqrest`) &mdash; Go standard library only. PascalCase
+- **Go** (`mqrestadmin`) &mdash; Go standard library only. PascalCase
   methods, `context.Context` on all I/O, zero external dependencies.
 
 All three wrap the `runCommandJSON` REST endpoint. No C client library
@@ -127,7 +127,7 @@ HTTPS.
 - `java.net.http.HttpClient` transport
 - Zero runtime dependencies beyond Gson
 
-**Go** (`mqrest`)
+**Go** (`mqrestadmin`)
 
 - Go standard library only, zero external dependencies
 - PascalCase method names (`DisplayQueue()`, `EnsureQlocal()`)


### PR DESCRIPTION
## Summary

- Fix Go package name from `mqrest` to `mqrestadmin` in the 1.1 announcement, matching the rename for parity with the Java namespace

## Test plan

- [x] `markdownlint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
