### PR TITLE
docs: rename mq-dev-environment references

### DIFF
--- a/fragments/development/local-mq-container.md
+++ b/fragments/development/local-mq-container.md
@@ -5,12 +5,12 @@ development and integration testing.
 
 - Docker Desktop or compatible Docker Engine.
 - IBM MQ container image access (license acceptance required).
-- The `mq-dev-environment` repository cloned as a sibling directory
-  (`../mq-dev-environment`), or set `MQ_DEV_ENV_PATH` to its location.
+- The `mq-rest-admin-dev-environment` repository cloned as a sibling directory
+  (`../mq-rest-admin-dev-environment`), or set `MQ_DEV_ENV_PATH` to its location.
 
 ## Configuration
 
-The Docker Compose file in the `mq-dev-environment` repository runs two
+The Docker Compose file in the `mq-rest-admin-dev-environment` repository runs two
 queue managers on a shared network (`mq-dev-net`):
 
 | Setting | QM1 | QM2 |
@@ -61,7 +61,7 @@ namelists, listeners, processes) plus cross-QM objects for communicating
 with QM2. QM2 receives a smaller set of objects plus the reciprocal
 cross-QM definitions.
 
-The seed scripts are maintained in the `mq-dev-environment` repository
+The seed scripts are maintained in the `mq-rest-admin-dev-environment` repository
 at `seed/base-qm1.mqsc` and `seed/base-qm2.mqsc`. Both use `REPLACE`
 so they can be re-run at any time without side effects.
 
@@ -84,7 +84,7 @@ so they can be re-run at any time without side effects.
 | `MQ_ADMIN_USER` | `mqadmin` | Admin username |
 | `MQ_ADMIN_PASSWORD` | `mqadmin` | Admin password |
 | `MQ_IMAGE` | `icr.io/ibm-messaging/mq:latest` | Container image |
-| `MQ_DEV_ENV_PATH` | `../mq-dev-environment` | Path to mq-dev-environment project |
+| `MQ_DEV_ENV_PATH` | `../mq-rest-admin-dev-environment` | Path to mq-rest-admin-dev-environment project |
 
 ## Gateway routing
 
@@ -119,7 +119,7 @@ If the REST API is not reachable, ensure the embedded web server is
 binding to all interfaces:
 
 ```bash
-docker compose -f ../mq-dev-environment/config/docker-compose.yml exec -T qm1 \
+docker compose -f ../mq-rest-admin-dev-environment/config/docker-compose.yml exec -T qm1 \
     setmqweb properties -k httpHost -v "*"
 ```
 

--- a/fragments/development/quality-gates.md
+++ b/fragments/development/quality-gates.md
@@ -157,7 +157,7 @@ repo configures Semgrep with language-specific rulesets.
 ### integration-tests
 
 End-to-end tests run against containerized IBM MQ queue managers
-provisioned by the `mq-dev-environment` repository. These tests issue
+provisioned by the `mq-rest-admin-dev-environment` repository. These tests issue
 real MQSC commands through the REST API and verify that:
 
 - Mapping data correctly translates between friendly names and MQ


### PR DESCRIPTION
## Summary

- Rename all `mq-dev-environment` references to `mq-rest-admin-dev-environment` in documentation fragments
- Phase 1, Step 1 of the repository rename plan

## Issue Linkage

- Ref wphillipmoore/mq-dev-environment#14
- Work is not complete until the issue is closed.

## Testing

- markdownlint — pre-existing warnings only, no new issues introduced

Docs-only: tests skipped

Files changed:
- `fragments/development/local-mq-container.md` (6 references)
- `fragments/development/quality-gates.md` (1 reference)

## Notes

- This is a pre-rename PR per the execution plan in the issue. It should be merged before the actual GitHub repository rename occurs.