### PR TITLE
refactor(docs): use shared docs-deploy composite action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,34 +29,10 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install MkDocs and mike
-        run: pip install mkdocs-material mike
-
       - name: Generate mapping docs
         run: python3 scripts/dev/generate_mapping_docs.py
 
-      - name: Configure git identity
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Determine version
-        id: version
-        run: |
-          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            VERSION=$(cat VERSION)
-            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-            echo "alias=latest" >> "$GITHUB_OUTPUT"
-          else
-            echo "version=dev" >> "$GITHUB_OUTPUT"
-            echo "alias=" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Deploy docs
-        run: |
-          if [ -n "${{ steps.version.outputs.alias }}" ]; then
-            mike deploy -F docs/site/mkdocs.yml --push --update-aliases ${{ steps.version.outputs.version }} ${{ steps.version.outputs.alias }}
-            mike set-default -F docs/site/mkdocs.yml --push latest
-          else
-            mike deploy -F docs/site/mkdocs.yml --push ${{ steps.version.outputs.version }}
-          fi
+        uses: wphillipmoore/standard-actions/actions/docs-deploy@develop
+        with:
+          version-command: cat VERSION


### PR DESCRIPTION
## Summary

Ref wphillipmoore/standard-actions#15

- Migrate docs workflow to use the shared `docs-deploy` composite action from standard-actions
- Common keeps its repo-specific pre-build step (generate_mapping_docs.py)
- Depends on wphillipmoore/standard-actions#33 being merged first

## Test plan

- [ ] Merge standard-actions PR first
- [ ] Verify docs deploy succeeds on develop push
- [ ] Confirm GitHub Pages site renders correctly