### PR TITLE
chore: add __pycache__ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,8 @@
 .cursorignore
 .cursorindexingignore
 
+# Python
+__pycache__/
+
 # Documentation
 docs/site/site/


### PR DESCRIPTION
# Pull Request

## Summary

- Add __pycache__ to .gitignore for shared Python dev tooling

## Issue Linkage

- Fixes #75

## Testing

- markdownlint

## Notes

- -
