### PR TITLE
docs: ban heredocs in shell commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,14 @@ creates divergent agent behavior across the multi-repo environment this project
 operates in. Consistency requires all guidance to live in shared, reviewable
 documentation.
 
+## Shell command policy
+
+**Do NOT use heredocs** (`<<EOF` / `<<'EOF'`) for multi-line arguments to CLI
+tools such as `gh`, `git commit`, or `curl`. Heredocs routinely fail due to
+shell escaping issues with apostrophes, backticks, and special characters.
+Always write multi-line content to a temporary file and pass it via `--body-file`
+or `--file` instead.
+
 ## Documentation Strategy
 
 This repository uses two complementary approaches for AI agent guidance:


### PR DESCRIPTION
# Pull Request

## Summary

- Ban heredocs in CLAUDE.md, mandate temp files

## Issue Linkage

- Ref wphillipmoore/standards-and-conventions#273

## Testing

- markdownlint

## Notes

- -
