### PR TITLE
chore(ci): standardize docs workflow version-command

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,4 +35,4 @@ jobs:
       - name: Deploy docs
         uses: wphillipmoore/standard-actions/actions/docs-deploy@develop
         with:
-          version-command: cat VERSION
+          version-command: cat VERSION | cut -d. -f1,2


### PR DESCRIPTION
# Pull Request

## Summary

- Standardize docs workflow version-command to use major.minor trimming

## Issue Linkage

- Fixes #88

## Testing

- markdownlint

## Notes

- -
