### PR TITLE
refactor(ci): remove docs-only detection and add tier-1 validation scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,19 +11,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  docs-only:
-    name: "ci: docs-only"
-    runs-on: ubuntu-latest
-    outputs:
-      docs-only: ${{ steps.detect.outputs.docs-only }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Detect docs-only changes
-        id: detect
-        uses: wphillipmoore/standard-actions/actions/docs-only-detect@develop
-
   standards-compliance:
     name: "ci: standards-compliance"
     runs-on: ubuntu-latest
@@ -37,18 +24,11 @@ jobs:
   shellcheck:
     name: "ci: shellcheck"
     runs-on: ubuntu-latest
-    needs: docs-only
     steps:
-      - name: Docs-only short-circuit
-        if: needs.docs-only.outputs.docs-only == 'true'
-        run: echo "Docs-only changes detected; skipping shellcheck."
-
       - name: Checkout code
-        if: needs.docs-only.outputs.docs-only != 'true'
         uses: actions/checkout@v6
 
       - name: Run shellcheck
-        if: needs.docs-only.outputs.docs-only != 'true'
         run: |
           files=$(find scripts -type f \( -name '*.sh' -o -path '*/git-hooks/*' \) | sort)
           if [ -n "$files" ]; then

--- a/scripts/dev/audit.sh
+++ b/scripts/dev/audit.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Tier 1 — Dependency audit
+
+echo "No dependency audit checks for this repository."

--- a/scripts/dev/lint.sh
+++ b/scripts/dev/lint.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Tier 1 — Lint
+
+files=$(find scripts -type f \( -name '*.sh' -o -path '*/git-hooks/*' \) | sort)
+if [ -n "$files" ]; then
+  echo "$files" | xargs shellcheck
+else
+  echo "No shell scripts found."
+fi

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Tier 1 — Test
+
+echo "No test suite for this repository."


### PR DESCRIPTION
# Pull Request

## Summary

- Remove docs-only CI detection and add standard tier-1 validation scripts

## Issue Linkage

- Fixes #102

## Testing

- markdownlint

## Notes

- -