### PR TITLE
chore(ci): update Python runtime from 3.12 to 3.14 in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,10 +24,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Python 3.12
+      - name: Set up Python 3.14
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - name: Generate mapping docs
         run: python3 scripts/dev/generate_mapping_docs.py


### PR DESCRIPTION
# Pull Request

## Summary

- Next-cycle dependency updates: bump Python 3.12 to 3.14 in docs workflow

## Issue Linkage

- Ref #107

## Testing

- markdownlint

## Notes

- -