### PR TITLE
fix: add name_required to DELETE QLOCAL/QREMOTE/QALIAS/QMODEL

### DIFF
--- a/mapping-data.json
+++ b/mapping-data.json
@@ -172,16 +172,20 @@
       "qualifier": "psid"
     },
     "DELETE QALIAS": {
-      "qualifier": "queue"
+      "qualifier": "queue",
+      "name_required": true
     },
     "DELETE QLOCAL": {
-      "qualifier": "queue"
+      "qualifier": "queue",
+      "name_required": true
     },
     "DELETE QMODEL": {
-      "qualifier": "queue"
+      "qualifier": "queue",
+      "name_required": true
     },
     "DELETE QREMOTE": {
-      "qualifier": "queue"
+      "qualifier": "queue",
+      "name_required": true
     },
     "DELETE QUEUE": {
       "qualifier": "queue",


### PR DESCRIPTION
# Pull Request

## Summary

- Add name_required to DELETE QLOCAL/QREMOTE/QALIAS/QMODEL in mapping-data.json

## Issue Linkage

- Fixes #130

## Testing

- markdownlint

## Notes

- -