### PR TITLE
chore(docs): strip CLAUDE.md boilerplate now covered by plugin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,89 +2,6 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Auto-memory policy
-
-**Do NOT use MEMORY.md.** Claude Code's auto-memory feature stores behavioral
-rules outside of version control, making them invisible to code review,
-inconsistent across repos, and unreliable across sessions. All behavioral rules,
-conventions, and workflow instructions belong in managed, version-controlled
-documentation (CLAUDE.md, AGENTS.md, skills, or docs/).
-
-If you identify a pattern, convention, or rule worth preserving:
-
-1. **Stop.** Do not write to MEMORY.md.
-2. **Discuss with the user** what you want to capture and why.
-3. **Together, decide** the correct managed location (CLAUDE.md, a skill file,
-   standards docs, or a new issue to track the gap).
-
-This policy exists because MEMORY.md is per-directory and per-machine — it
-creates divergent agent behavior across the multi-repo environment this project
-operates in. Consistency requires all guidance to live in shared, reviewable
-documentation.
-
-## Shell command policy
-
-**Do NOT use heredocs** (`<<EOF` / `<<'EOF'`) for multi-line arguments to CLI
-tools such as `gh`, `git commit`, or `curl`. Heredocs routinely fail due to
-shell escaping issues with apostrophes, backticks, and special characters.
-Always write multi-line content to a temporary file and pass it via `--body-file`
-or `--file` instead.
-
-## Documentation Strategy
-
-This repository uses two complementary approaches for AI agent guidance:
-
-- **AGENTS.md**: Generic AI agent instructions using include directives to force documentation indexing. Contains canonical standards references, shared skills loading, and user override support.
-- **CLAUDE.md** (this file): Claude Code-specific guidance with prescriptive commands, architecture details, and development workflows optimized for `/init`.
-
-### Integration Approach
-
-**For Claude Code** (`/init` command):
-1. Read CLAUDE.md (this file) first for optimized quick-start guidance
-2. Process include directives to load repository standards
-3. Reference AGENTS.md for shared skills and canonical standards location
-4. Apply layered standards: canonical → project-specific → user overrides
-
-**For other AI agents** (Codex, generic LLMs):
-1. Read AGENTS.md first as the primary entry point
-2. Process include directives to load all referenced documentation
-3. Resolve canonical standards repo path (local or GitHub)
-4. Load shared skills from standards repo
-5. Apply user overrides from `~/AGENTS.md` if present
-
-**Key differences**:
-- **CLAUDE.md**: Prescriptive, command-focused, optimized for `/init`
-- **AGENTS.md**: Declarative, include-directive-driven, forces full documentation indexing
-
-Both files share the same underlying standards via include directives, ensuring consistency across all AI agents working in this repository.
-
-### Best Practices for Dual-File Approach
-
-**What goes in AGENTS.md**:
-- Include directives for documentation indexing
-- Canonical standards repository references
-- Shared skills loading instructions
-- User override mechanisms
-- Minimal, declarative content
-
-**What goes in CLAUDE.md**:
-- Claude Code-specific quick-start commands
-- Detailed architecture and design patterns
-- Implementation notes and common workflows
-- Integration guidance between the two files
-- More verbose, prescriptive content
-
-**What goes in neither (use includes instead)**:
-- Repository standards (keep in `docs/repository-standards.md`)
-- Canonical standards (reference external repo)
-- Project-specific conventions (keep in referenced docs)
-
-**Maintenance strategy**:
-- Update standards in source files, not in AGENTS.md or CLAUDE.md
-- Use include directives to pull in shared content
-- Keep AGENTS.md minimal and CLAUDE.md focused on Claude Code workflows
-- Test both entry points when updating documentation structure
-
 <!-- include: docs/standards-and-conventions.md -->
 <!-- include: docs/repository-standards.md -->
 
@@ -158,64 +75,6 @@ attribute mapping definitions. It contains:
 - **Documentation sites**: Each language repo clones this repository and uses its
   documentation tool's include mechanism (`pymdownx.snippets`, MyST `{include}`)
 
-## Documentation Indexing Strategy
-
-This repository uses `<!-- include: path/to/file.md -->` directives to force documentation indexing. When you encounter these directives:
-
-1. **Read the referenced files** to understand the full context
-2. **Apply layered standards** in order:
-   - Canonical standards (from `standards-and-conventions` repo)
-   - Project-specific standards (`docs/repository-standards.md`)
-   - User overrides (`~/AGENTS.md` if present)
-3. **Load shared skills** from `<standards-repo-path>/skills/**/SKILL.md`
-
-The include directives appear in:
-- `AGENTS.md` - Includes repository standards and conventions
-- `CLAUDE.md` - Includes same standards for Claude Code
-- `docs/standards-and-conventions.md` - Includes canonical standards reference
-
-This approach ensures all AI agents (Codex, Claude, etc.) have access to the same foundational documentation.
-
-## Documentation Structure
-
-- `README.md` - Project overview and quick start
-- `AGENTS.md` - Generic AI agent instructions with include directives
-- `CLAUDE.md` - This file, Claude Code-specific guidance
-- `docs/repository-standards.md` - Project-specific standards (included from AGENTS.md)
-- `docs/standards-and-conventions.md` - Canonical standards reference (includes external repo)
-
-## Commit and PR Scripts
-
-**NEVER use raw `git commit`** — always use `st-commit`.
-**NEVER use raw `gh pr create`** — always use `st-submit-pr`.
-
-### Committing
-
-```bash
-st-commit --type feat --message "add new mapping fragment" --agent claude
-st-commit --type docs --message "update mapping documentation" --agent claude
-```
-
-- `--type` (required): `feat|fix|docs|style|refactor|test|chore|ci|build`
-- `--message` (required): commit description
-- `--agent` (required): `claude` or `codex` — resolves the correct `Co-Authored-By` identity
-- `--scope` (optional): conventional commit scope
-- `--body` (optional): detailed commit body
-
-### Submitting PRs
-
-```bash
-st-submit-pr --issue 42 --summary "Add new mapping fragment for X"
-st-submit-pr --issue 42 --linkage Ref --summary "Update docs"
-```
-
-- `--issue` (required): GitHub issue number (just the number)
-- `--summary` (required): one-line PR summary
-- `--linkage` (optional, default: `Fixes`): `Fixes|Closes|Resolves|Ref`
-- `--title` (optional): PR title (default: most recent commit subject)
-- `--notes` (optional): additional notes
-- `--dry-run` (optional): print generated PR without executing
-
 ## Local MQ Environment
 
 Each language repo (Python, Java, Go, Ruby, Rust) includes thin wrapper
@@ -267,10 +126,6 @@ export MQ_REST_ADMIN_RUN_INTEGRATION=true
 
 ## Key References
 
-**Canonical Standards**: https://github.com/wphillipmoore/standards-and-conventions
-- Local path (preferred): `../standards-and-conventions`
-- Load all skills from: `<standards-repo-path>/skills/**/SKILL.md`
-
 **Sibling repositories**:
 - `../mq-rest-admin-python` — Python implementation
 - `../mq-rest-admin-java` — Java implementation
@@ -279,5 +134,3 @@ export MQ_REST_ADMIN_RUN_INTEGRATION=true
 **External Documentation**:
 - IBM MQ 9.4 administrative REST API
 - MQSC command reference
-
-**User Overrides**: `~/AGENTS.md` (optional, applied if present and readable)


### PR DESCRIPTION
# Pull Request

## Summary

- Strip CLAUDE.md boilerplate now covered by standard-tooling plugin

## Issue Linkage

- Fixes #146

## Testing

- markdownlint

## Notes

- -