### PR TITLE
chore: use .markdownlintignore for lint exclusions

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,1 +1,4 @@
+CHANGELOG.md
+releases/
+docs/announcements/
 docs/site/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ git config core.hooksPath ../standard-tooling/scripts/lib/git-hooks             
 ### Validation
 
 ```bash
-markdownlint '**/*.md'    # Lint all Markdown files
+markdownlint .            # Lint all Markdown files
 ```
 
 ## Architecture

--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -32,7 +32,7 @@
 ## Local validation
 
 ```bash
-markdownlint '**/*.md'    # Lint all Markdown files
+markdownlint .            # Lint all Markdown files
 ```
 
 ## Merge strategy override


### PR DESCRIPTION
# Pull Request

## Summary

- Update .markdownlintignore with full exclusion list (CHANGELOG.md, releases/, docs/announcements/)
- Change documented validation command from `markdownlint '**/*.md'` to `markdownlint .` in CLAUDE.md and docs/repository-standards.md

## Issue Linkage

- Ref #190

## Testing

- markdownlint

## Notes

- Part of cross-repo rollout across all managed repositories