### PR TITLE
refactor: migrate publish workflow to shared reusable workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,62 +9,24 @@ permissions:
   contents: write
   pull-requests: write
 
-concurrency:
-  group: publish
-  cancel-in-progress: false
-
 jobs:
   publish:
-    name: "publish: release"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
+    uses: wphillipmoore/standard-actions/.github/workflows/publish-release.yml@develop
+    permissions:
+      contents: write
+      pull-requests: write
+    with:
+      ecosystem: none
+      version-command: cat VERSION
+      release-title: mq-rest-admin-common
+      release-notes: |
+        ## Links
 
-      - name: Extract version
-        id: version
-        run: |
-          version=$(cat VERSION)
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "tag=v$version" >> "$GITHUB_OUTPUT"
-
-      - name: Check if tag already exists
-        id: tag_check
-        run: |
-          if git rev-parse "${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Tag and release
-        if: steps.tag_check.outputs.exists == 'false'
-        uses: wphillipmoore/standard-actions/actions/publish/tag-and-release@v1.1
-        with:
-          version: ${{ steps.version.outputs.version }}
-          release-title: mq-rest-admin-common
-          release-notes: |
-            ## Links
-
-            - [Documentation](https://wphillipmoore.github.io/mq-rest-admin-common/)
-
-      - name: Generate app token for bump PR
-        if: steps.tag_check.outputs.exists == 'false'
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-
-      - name: Version bump PR
-        if: steps.tag_check.outputs.exists == 'false'
-        uses: wphillipmoore/standard-actions/actions/publish/version-bump-pr@v1.1
-        with:
-          current-version: ${{ steps.version.outputs.version }}
-          version-file: VERSION
-          version-regex: '(.*)'
-          version-replacement: '{version}'
-          develop-version-command: cat
-          app-token: ${{ steps.app-token.outputs.token }}
+        - [Documentation](https://wphillipmoore.github.io/mq-rest-admin-common/)
+      version-file: VERSION
+      version-regex: '(.*)'
+      version-replacement: '{version}'
+      develop-version-command: cat
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -4,3 +4,4 @@ docs/announcements/
 docs/site/
 AGENTS.md
 CLAUDE.md
+fragments/

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -2,3 +2,5 @@ CHANGELOG.md
 releases/
 docs/announcements/
 docs/site/
+AGENTS.md
+CLAUDE.md


### PR DESCRIPTION
## Summary

- Replace per-repo publish.yml with thin caller that delegates to the shared `publish-release.yml` reusable workflow in standard-actions
- All ecosystem-specific behavior is passed as inputs to the shared workflow
- Consistent action refs, step ordering, and SBOM output normalization

Ref wphillipmoore/standard-actions#171

## Test plan

- [ ] Verify CI passes on this branch
- [ ] After standard-actions#171 merges to develop, verify publish workflow runs correctly on next release
- [ ] Confirm idempotency: re-run on existing tag should skip all mutating steps
