### PR TITLE
chore: update CLAUDE.md for docker-only standard-tooling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,10 +25,11 @@ This is a documentation-only repository. There are no build or test commands.
 ### Environment Setup
 
 ```bash
-cd ../standard-tooling && uv sync                                                # Install standard-tooling
-export PATH="../standard-tooling/.venv/bin:../standard-tooling/scripts/bin:$PATH" # Put tools on PATH
-git config core.hooksPath ../standard-tooling/scripts/lib/git-hooks               # Enable git hooks
+git config core.hooksPath ../standard-tooling/scripts/lib/git-hooks  # Enable git hooks
 ```
+
+Standard-tooling CLI tools (`st-commit`, `st-validate-local`, etc.) are
+pre-installed in the dev container images. No local setup required.
 
 ### Validation
 


### PR DESCRIPTION
## Summary

- Remove manual standard-tooling setup (uv sync, PATH manipulation) from CLAUDE.md
- Standard-tooling CLI tools are now pre-installed in dev container images
- Keep git hooks configuration (runs locally, not in container)

## Test plan

- [ ] CI passes

Closes #156
Ref wphillipmoore/standard-tooling#213

🤖 Generated with [Claude Code](https://claude.com/claude-code)