### PR TITLE
ci: use dev-docs container for standards-compliance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
   standards-compliance:
     name: "ci: standards-compliance"
     runs-on: ubuntu-latest
+    container: ghcr.io/wphillipmoore/dev-docs:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Validate standards
-        uses: wphillipmoore/standard-actions/actions/standards-compliance@v1.1
+        uses: wphillipmoore/standard-actions/actions/standards-compliance@develop
 
   shellcheck:
     name: "ci: shellcheck"


### PR DESCRIPTION
## Summary

Ref wphillipmoore/standard-tooling#214

- Add container: ghcr.io/wphillipmoore/dev-docs:latest to the standards-compliance job
- Matches the updated standards-compliance action which now requires pre-installed standard-tooling

Depends on wphillipmoore/standard-actions#179

## Test plan

- [ ] CI passes with dev-docs container
- [ ] Merge after standard-actions#179 lands

Generated with [Claude Code](https://claude.com/claude-code)