### PR TITLE
chore: use st-docker-test instead of legacy docker-test wrapper

### DIFF
--- a/scripts/dev/lint.sh
+++ b/scripts/dev/lint.sh
@@ -5,9 +5,9 @@ set -euo pipefail
 export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-python:3.14}"
 export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-files=\$(find scripts -type f \\( -name '*.sh' -o -path '*/git-hooks/*' \\) | sort) && if [ -n \"\$files\" ]; then echo \"\$files\" | xargs shellcheck; else echo 'No shell scripts found.'; fi}"
 
-if ! command -v docker-test >/dev/null 2>&1; then
-  echo "ERROR: docker-test not found on PATH." >&2
-  echo "Set up standard-tooling: export PATH=../standard-tooling/scripts/bin:\$PATH" >&2
+if ! command -v st-docker-test >/dev/null 2>&1; then
+  echo "ERROR: st-docker-test not found on PATH." >&2
+  echo "Set up standard-tooling: export PATH=../standard-tooling/.venv/bin:\$PATH" >&2
   exit 1
 fi
-exec docker-test
+exec st-docker-test


### PR DESCRIPTION
# Pull Request

## Summary

- Update scripts/dev/lint.sh to use st-docker-test instead of legacy docker-test wrapper, and update PATH hint from scripts/bin to .venv/bin.

## Issue Linkage

- Fixes #160

## Testing

- markdownlint

## Notes

- -