### PR TITLE
fix(docs): flip docs container from dev-docs to dev-base

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
   deploy:
     name: "deploy: docs"
     runs-on: ubuntu-latest
-    container: ghcr.io/wphillipmoore/dev-docs:latest
+    container: ghcr.io/wphillipmoore/dev-base:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
# Pull Request

## Summary

- flip docs container to dev-base (drop-in replacement for removed dev-docs)

## Issue Linkage

- Fixes #164

## Testing

- markdownlint

## Notes

- One-line container image rename. Documentation workflow has been failing since the image rename landed in standard-tooling-docker#44. Drop-in replacement — same image, same tooling.