### PR TITLE
chore: strip config sections from repository-standards.md

### DIFF
--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -3,8 +3,6 @@
 ## Table of Contents
 
 - [Pre-flight checklist](#pre-flight-checklist)
-- [AI co-authors](#ai-co-authors)
-- [Repository profile](#repository-profile)
 - [Local validation](#local-validation)
 - [Merge strategy override](#merge-strategy-override)
 
@@ -14,20 +12,6 @@
 - If on `develop`, create a short-lived `feature/*` branch or ask for explicit approval to proceed on `develop`.
 - If approval is granted to work on `develop`, call it out in the response and proceed only for that user-approved scope.
 - Enable repository git hooks before committing: `git config core.hooksPath scripts/git-hooks`.
-
-## AI co-authors
-
-- Co-Authored-By: wphillipmoore-codex <255923655+wphillipmoore-codex@users.noreply.github.com>
-- Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>
-
-## Repository profile
-
-- repository_type: library
-- versioning_scheme: library
-- branching_model: library-release
-- release_model: artifact-publishing
-- supported_release_lines: current and previous
-- primary_language: none
 
 ## Local validation
 
@@ -64,9 +48,8 @@ st-commit \
 - `--scope` (optional): conventional commit scope
 - `--body` (optional): detailed commit body
 
-The script resolves the correct `Co-Authored-By` identity from the
-[AI co-authors](#ai-co-authors) section and the git hooks validate
-the result.
+The script resolves the correct `Co-Authored-By` identity from
+`standard-tooling.toml` and the git hooks validate the result.
 
 ### Submitting PRs
 


### PR DESCRIPTION
# Pull Request

## Summary

- Strip AI co-authors and Repository profile sections from repository-standards.md — values now in standard-tooling.toml

## Issue Linkage

- Ref #171

## Testing

- markdownlint

## Notes

- -