### PR TITLE
chore: add [ci] section to standard-tooling.toml

### DIFF
--- a/standard-tooling.toml
+++ b/standard-tooling.toml
@@ -9,6 +9,10 @@ primary-language = "none"
 claude = "Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>"
 codex = "Co-Authored-By: wphillipmoore-codex <255923655+wphillipmoore-codex@users.noreply.github.com>"
 
+[ci]
+versions = ["latest"]
+integration-tests = false
+
 [publish]
 release = true
 docs = true


### PR DESCRIPTION
## Summary

- Add the missing `[ci]` section to `standard-tooling.toml` with `versions = ["latest"]` and `integration-tests = false`
- This is required by `st-github-config` audit/apply, which crashes when the section is absent

Ref #192

## Test plan

- [ ] Verify `st-github-config audit` no longer crashes on this repo
- [ ] Verify `st-github-config apply` works correctly