### PR TITLE
chore: migrate to mq-rest-admin-project org and vergil tooling

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,13 +1,13 @@
 {
   "extraKnownMarketplaces": {
-    "standard-tooling-marketplace": {
+    "vergil-marketplace": {
       "source": {
         "source": "github",
-        "repo": "wphillipmoore/standard-tooling-plugin"
+        "repo": "vergil-project/vergil-plugin"
       }
     }
   },
   "enabledPlugins": {
-    "standard-tooling@standard-tooling-marketplace": true
+    "vergil@vergil-marketplace": true
   }
 }

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-# Source: wphillipmoore/standard-tooling/.github/ISSUE_TEMPLATE/config.yml
+# Source: vergil-project/vergil-tooling/.github/ISSUE_TEMPLATE/config.yml
 # Do not modify repo-local copies — update the source and re-sync.
 #
 blank_issues_enabled: false

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,4 +1,4 @@
-# https://github.com/wphillipmoore/standard-actions/blob/develop/.github/workflows/README.md
+# https://github.com/vergil-project/vergil-actions/blob/develop/.github/workflows/README.md
 name: CD
 
 on:
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   docs:
-    uses: wphillipmoore/standard-actions/.github/workflows/cd-docs.yml@v1.5
+    uses: vergil-project/vergil-actions/.github/workflows/cd-docs.yml@v2.0
     with:
       pre-deploy-command: python3 scripts/dev/generate_mapping_docs.py
     permissions:
@@ -22,5 +22,7 @@ jobs:
 
   release:
     if: github.ref == 'refs/heads/main'
-    uses: wphillipmoore/standard-actions/.github/workflows/cd-release.yml@v1.5
-    secrets: inherit
+    uses: vergil-project/vergil-actions/.github/workflows/cd-release.yml@v2.0
+    secrets:
+      APP_CLIENT_ID: ${{ secrets.APP_CLIENT_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# https://github.com/wphillipmoore/standard-actions/blob/develop/.github/workflows/README.md
+# https://github.com/vergil-project/vergil-actions/blob/develop/.github/workflows/README.md
 name: CI
 
 on:
@@ -21,14 +21,14 @@ concurrency:
 
 jobs:
   quality:
-    uses: wphillipmoore/standard-actions/.github/workflows/ci-quality.yml@v1.5
+    uses: vergil-project/vergil-actions/.github/workflows/ci-quality.yml@v2.0
     with:
       language: shell
       versions: '["latest"]'
       container-suffix: base
 
   security:
-    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.5
+    uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v2.0
     with:
       language: shell
       run-codeql: false
@@ -39,7 +39,7 @@ jobs:
       security-events: write
 
   version:
-    uses: wphillipmoore/standard-actions/.github/workflows/ci-version-bump.yml@v1.5
+    uses: vergil-project/vergil-actions/.github/workflows/ci-version-bump.yml@v2.0
     with:
       language: shell
       run-release: ${{ inputs.run-release != 'false' }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,8 @@
 # Agent Instructions
 
-**Standards reference**: <https://github.com/wphillipmoore/standards-and-conventions>
-— active standards documentation lives in the standard-tooling repository under `docs/`.
-Repository profile: `standard-tooling.toml`.
+**Standards reference**: <https://github.com/vergil-project/vergil-tooling>
+— active standards documentation lives in the vergil-tooling repository under `docs/`.
+Repository profile: `vergil.toml`.
 
 ## User Overrides (Optional)
 
@@ -13,13 +13,13 @@ briefly and continue.
 ## Canonical Standards
 
 This repository follows the canonical standards and conventions in the
-`standards-and-conventions` repository.
+`vergil-tooling` repository.
 
 Resolve the local path (preferred):
-- `../standards-and-conventions`
+- `../vergil-tooling`
 
 If the local path is unavailable, use the canonical web source:
-- https://github.com/wphillipmoore/standards-and-conventions
+- https://github.com/vergil-project/vergil-tooling
 
 If the canonical standards cannot be retrieved, treat it as a fatal
 exception and stop.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,9 +2,9 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-**Standards reference**: <https://github.com/wphillipmoore/standards-and-conventions>
-— active standards documentation lives in the standard-tooling repository under `docs/`.
-Repository profile: `standard-tooling.toml`.
+**Standards reference**: <https://github.com/vergil-project/vergil-tooling>
+— active standards documentation lives in the vergil-tooling repository under `docs/`.
+Repository profile: `vergil.toml`.
 
 ## Memory management
 
@@ -15,9 +15,9 @@ plugin/skill issue) before writing. See that file for the full
 workflow.
 
 Available skills:
-- `/standard-tooling:memory-init` — set up or update the policy header
+- `/vergil:memory-init` — set up or update the policy header
   in a project's `MEMORY.md`.
-- `/standard-tooling:memory-audit` — structured collaborative review
+- `/vergil:memory-audit` — structured collaborative review
   of memory files.
 
 ## Parallel AI agent development
@@ -28,9 +28,9 @@ while preserving shared project memory (which Claude Code derives from the
 session's starting CWD).
 
 **Canonical spec:**
-[`standard-tooling/docs/specs/worktree-convention.md`](https://github.com/wphillipmoore/standard-tooling/blob/develop/docs/specs/worktree-convention.md)
+[`vergil-tooling/docs/specs/worktree-convention.md`](https://github.com/vergil-project/vergil-tooling/blob/develop/docs/specs/worktree-convention.md)
 — full rationale, trust model, failure modes, and memory-path implications.
-The canonical text lives in `standard-tooling`; this section is the local
+The canonical text lives in `vergil-tooling`; this section is the local
 on-ramp.
 
 ### Structure
@@ -97,7 +97,7 @@ This is the shared common repository for the mq-rest-admin project family, servi
 
 **Status**: Active
 
-**Canonical Standards**: This repository follows standards at https://github.com/wphillipmoore/standards-and-conventions (local path: `../standards-and-conventions` if available)
+**Canonical Standards**: This repository follows standards at https://github.com/vergil-project/vergil-tooling (local path: `../vergil-tooling` if available)
 
 ## Development Commands
 
@@ -106,16 +106,16 @@ This is a documentation-only repository. There are no build or test commands.
 ### Environment Setup
 
 ```bash
-git config core.hooksPath ../standard-tooling/scripts/lib/git-hooks  # Enable git hooks
+git config core.hooksPath ../vergil-tooling/scripts/lib/git-hooks  # Enable git hooks
 ```
 
-Standard-tooling CLI tools (`st-commit`, `st-validate`, etc.) are
+VERGIL CLI tools (`vrg-commit`, `vrg-validate`, etc.) are
 pre-installed in the dev container images. No local setup required.
 
 ### Validation
 
 ```bash
-st-docker-run -- st-validate   # Full validation (runs in dev container)
+vrg-docker-run -- vrg-validate   # Full validation (runs in dev container)
 ```
 
 ## Architecture
@@ -162,13 +162,13 @@ attribute mapping definitions. It contains:
 Each language repo (Python, Java, Go, Ruby, Rust) includes thin wrapper
 scripts for managing a local MQ container environment. The actual Docker
 Compose configuration is owned by the
-[mq-rest-admin-dev-environment](https://github.com/wphillipmoore/mq-rest-admin-dev-environment)
+[mq-rest-admin-dev-environment](https://github.com/mq-rest-admin-project/mq-rest-admin-dev-environment)
 repository, which must be cloned as a sibling directory.
 
 ### Prerequisite
 
 ```bash
-git clone https://github.com/wphillipmoore/mq-rest-admin-dev-environment.git ../mq-rest-admin-dev-environment
+git clone https://github.com/mq-rest-admin-project/mq-rest-admin-dev-environment.git ../mq-rest-admin-dev-environment
 ```
 
 ### Lifecycle scripts (in each language repo)

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Shared documentation fragments for the mq-rest-admin project family.
 This repository contains language-neutral documentation fragments that are
 composed into per-language documentation sites for:
 
-- [mq-rest-admin-java](https://github.com/wphillipmoore/mq-rest-admin-java) — Java (MkDocs + Material)
-- [mq-rest-admin-python](https://github.com/wphillipmoore/mq-rest-admin-python) — Python (Sphinx + MyST)
-- [mq-rest-admin-go](https://github.com/wphillipmoore/mq-rest-admin-go) — Go (future)
+- [mq-rest-admin-java](https://github.com/mq-rest-admin-project/mq-rest-admin-java) — Java (MkDocs + Material)
+- [mq-rest-admin-python](https://github.com/mq-rest-admin-project/mq-rest-admin-python) — Python (Sphinx + MyST)
+- [mq-rest-admin-go](https://github.com/mq-rest-admin-project/mq-rest-admin-go) — Go (future)
 
 ## Fragment structure
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,13 @@ Shared documentation fragments for the mq-rest-admin project family.
 This repository contains language-neutral documentation fragments that are
 composed into per-language documentation sites for:
 
-- [mq-rest-admin-java](https://github.com/mq-rest-admin-project/mq-rest-admin-java) — Java (MkDocs + Material)
-- [mq-rest-admin-python](https://github.com/mq-rest-admin-project/mq-rest-admin-python) — Python (Sphinx + MyST)
-- [mq-rest-admin-go](https://github.com/mq-rest-admin-project/mq-rest-admin-go) — Go (future)
+- [mq-rest-admin-java][java] — Java (MkDocs + Material)
+- [mq-rest-admin-python][python] — Python (Sphinx + MyST)
+- [mq-rest-admin-go][go] — Go (future)
+
+[java]: https://github.com/mq-rest-admin-project/mq-rest-admin-java
+[python]: https://github.com/mq-rest-admin-project/mq-rest-admin-python
+[go]: https://github.com/mq-rest-admin-project/mq-rest-admin-go
 
 ## Fragment structure
 

--- a/docs/plans/2026-05-14-mq-rest-admin-migration.md
+++ b/docs/plans/2026-05-14-mq-rest-admin-migration.md
@@ -1,0 +1,701 @@
+# MQ REST Admin Migration — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps
+> use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Transfer all 8 mq-rest-admin repositories from `wphillipmoore`
+to `mq-rest-admin-project`, update all 7 active repos to post-VERGIL
+tooling names, and verify everything works.
+
+**Architecture:** Batch transfer in dependency order, then per-repo
+migration using a shared template with repo-specific deltas. Each repo
+gets one feature branch and one PR.
+
+**Spec:** `docs/specs/2026-05-14-mq-rest-admin-migration-design.md`
+
+**Relationship to org governance plan:** This is Plan B (migration).
+The org governance plan
+(`docs/plans/2026-05-14-mq-rest-admin-org-governance-setup.md`) is
+Plan A. Plan A Phase 1 (Tasks 1–3) must complete before this plan
+begins. Plan A Phase 2 (Tasks 4–10) executes after Task 2 of this plan
+completes.
+
+**Prerequisites:**
+- VERGIL rename complete (all tooling at post-VERGIL names)
+- `mq-rest-admin-project` org governance Phase 1 complete (Tasks 1–3)
+- No open PRs on any of the 8 repos
+- Clean working state on `develop` for all active repos
+
+---
+
+## Task 1: Pre-Flight Checks
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Verify no open PRs on any repo**
+
+  ```bash
+  for repo in mq-rest-admin-common mq-rest-admin-python mq-rest-admin-java \
+    mq-rest-admin-go mq-rest-admin-ruby mq-rest-admin-rust \
+    mq-rest-admin-dev-environment mq-rest-admin-template; do
+    count=$(gh pr list --repo wphillipmoore/$repo --state open --json number --jq 'length')
+    echo "$repo: $count open PRs"
+  done
+  ```
+
+  Expected: all repos show 0 open PRs. If any exist, merge or close
+  them first.
+
+- [ ] **Step 2: Verify clean working state for all active repos**
+
+  ```bash
+  for repo in mq-rest-admin-common mq-rest-admin-python mq-rest-admin-java \
+    mq-rest-admin-go mq-rest-admin-ruby mq-rest-admin-rust \
+    mq-rest-admin-dev-environment; do
+    echo "=== $repo ==="
+    cd ~/dev/github/$repo
+    git status --short
+    git log --oneline -1
+    cd -
+  done
+  ```
+
+  Expected: all on `develop`, clean working trees, up to date with
+  origin.
+
+- [ ] **Step 3: Verify org governance Phase 1 is complete**
+
+  ```bash
+  gh api orgs/mq-rest-admin-project --jq '.login'
+  # Expected: mq-rest-admin-project
+
+  security find-generic-password -s "mq-rest-admin/app-private-key" -w > /dev/null \
+    && echo "app-private-key: OK"
+  ```
+
+- [ ] **Step 4: Verify vergil-actions v2.0 exists**
+
+  ```bash
+  gh release view v2.0.0 --repo vergil-project/vergil-actions \
+    --json tagName --jq '.tagName'
+  ```
+
+  Expected: `v2.0.0`. If this fails, the VERGIL rename is not
+  complete — do not proceed.
+
+---
+
+## Task 2: Transfer Sequence
+
+**Files:** None (GitHub API operations)
+
+Transfer repos one at a time in dependency order. After each transfer,
+verify success before proceeding. If any transfer fails, stop and
+diagnose before continuing.
+
+- [ ] **Step 1: Transfer `mq-rest-admin-dev-environment`**
+
+  ```bash
+  gh api repos/wphillipmoore/mq-rest-admin-dev-environment/transfer \
+    -f new_owner=mq-rest-admin-project --silent
+  sleep 10
+  gh api repos/mq-rest-admin-project/mq-rest-admin-dev-environment \
+    --jq '.full_name'
+  ```
+
+  Expected: `mq-rest-admin-project/mq-rest-admin-dev-environment`
+
+- [ ] **Step 2: Transfer `mq-rest-admin-common`**
+
+  ```bash
+  gh api repos/wphillipmoore/mq-rest-admin-common/transfer \
+    -f new_owner=mq-rest-admin-project --silent
+  sleep 10
+  gh api repos/mq-rest-admin-project/mq-rest-admin-common \
+    --jq '.full_name'
+  ```
+
+- [ ] **Step 3: Transfer `mq-rest-admin-python`**
+
+  ```bash
+  gh api repos/wphillipmoore/mq-rest-admin-python/transfer \
+    -f new_owner=mq-rest-admin-project --silent
+  sleep 10
+  gh api repos/mq-rest-admin-project/mq-rest-admin-python \
+    --jq '.full_name'
+  ```
+
+- [ ] **Step 4: Transfer `mq-rest-admin-java`**
+
+  ```bash
+  gh api repos/wphillipmoore/mq-rest-admin-java/transfer \
+    -f new_owner=mq-rest-admin-project --silent
+  sleep 10
+  gh api repos/mq-rest-admin-project/mq-rest-admin-java \
+    --jq '.full_name'
+  ```
+
+- [ ] **Step 5: Transfer `mq-rest-admin-go`**
+
+  ```bash
+  gh api repos/wphillipmoore/mq-rest-admin-go/transfer \
+    -f new_owner=mq-rest-admin-project --silent
+  sleep 10
+  gh api repos/mq-rest-admin-project/mq-rest-admin-go \
+    --jq '.full_name'
+  ```
+
+- [ ] **Step 6: Transfer `mq-rest-admin-ruby`**
+
+  ```bash
+  gh api repos/wphillipmoore/mq-rest-admin-ruby/transfer \
+    -f new_owner=mq-rest-admin-project --silent
+  sleep 10
+  gh api repos/mq-rest-admin-project/mq-rest-admin-ruby \
+    --jq '.full_name'
+  ```
+
+- [ ] **Step 7: Transfer `mq-rest-admin-rust`**
+
+  ```bash
+  gh api repos/wphillipmoore/mq-rest-admin-rust/transfer \
+    -f new_owner=mq-rest-admin-project --silent
+  sleep 10
+  gh api repos/mq-rest-admin-project/mq-rest-admin-rust \
+    --jq '.full_name'
+  ```
+
+- [ ] **Step 8: Transfer `mq-rest-admin-template`**
+
+  ```bash
+  gh api repos/wphillipmoore/mq-rest-admin-template/transfer \
+    -f new_owner=mq-rest-admin-project --silent
+  sleep 10
+  gh api repos/mq-rest-admin-project/mq-rest-admin-template \
+    --jq '.full_name'
+  ```
+
+  This repo is archived. Transfer only — no per-repo migration.
+
+- [ ] **Step 9: Verify all transfers succeeded**
+
+  ```bash
+  for repo in mq-rest-admin-dev-environment mq-rest-admin-common \
+    mq-rest-admin-python mq-rest-admin-java mq-rest-admin-go \
+    mq-rest-admin-ruby mq-rest-admin-rust mq-rest-admin-template; do
+    result=$(gh api repos/mq-rest-admin-project/$repo --jq '.full_name' 2>/dev/null)
+    echo "$repo: ${result:-FAILED}"
+  done
+  ```
+
+  Expected: all 8 repos show `mq-rest-admin-project/<name>`.
+
+- [ ] **Step 10: Update local git remotes**
+
+  ```bash
+  for repo in mq-rest-admin-common mq-rest-admin-python mq-rest-admin-java \
+    mq-rest-admin-go mq-rest-admin-ruby mq-rest-admin-rust \
+    mq-rest-admin-dev-environment; do
+    cd ~/dev/github/$repo
+    git remote set-url origin git@github.com:mq-rest-admin-project/$repo.git
+    git fetch origin
+    echo "$repo: $(git remote get-url origin)"
+    cd -
+  done
+  ```
+
+- [ ] **Step 11: Proceed to governance Phase 2**
+
+  All transfers are complete. Run Plan A Phase 2 (Tasks 4–10) now
+  before continuing with per-repo migrations.
+
+---
+
+## Task 3: Per-Repo Migration Template
+
+This is the canonical task sequence for migrating one repo. It is not
+a standalone task — Tasks 4–10 each execute this template with
+repo-specific adjustments.
+
+The template is included here as a reference. Each per-repo task
+below lists only its **delta** (repo-specific additions or
+modifications to the template steps).
+
+### Template Steps
+
+**T1. Pre-flight checks**
+
+```bash
+cd ~/dev/github/<repo>
+git status
+git log --oneline -1
+git remote get-url origin
+# Verify: on develop, clean, remote points to mq-rest-admin-project
+```
+
+**T2. Create feature branch**
+
+```bash
+git checkout -b feature/<issue>-org-migration
+```
+
+**T3. Rename config file**
+
+```bash
+git mv standard-tooling.toml vergil.toml
+```
+
+**T4. Update vergil.toml contents**
+
+Replace the full file contents. The key changes:
+- `[dependencies]`: `standard-tooling = "v1.4"` → `vergil = "v2.0"`
+- `[project.co-authors]`: Replace `claude` and `codex` entries with
+  single `agent` entry using `wphillipmoore-agent` noreply email
+
+Get the agent user ID:
+```bash
+gh api users/wphillipmoore-agent --jq '.id'
+```
+
+**T5. Update CI/CD workflows**
+
+In `.github/workflows/ci.yml` and `.github/workflows/cd.yml`:
+
+```bash
+sed -i '' \
+  -e 's|wphillipmoore/standard-actions|vergil-project/vergil-actions|g' \
+  -e 's|@v1\.5|@v2.0|g' \
+  -e 's|wphillipmoore/mq-rest-admin-dev-environment|mq-rest-admin-project/mq-rest-admin-dev-environment|g' \
+  .github/workflows/ci.yml .github/workflows/cd.yml
+```
+
+**T6. Update issue templates**
+
+```bash
+sed -i '' \
+  's|wphillipmoore/standard-tooling|vergil-project/vergil-tooling|g' \
+  .github/ISSUE_TEMPLATE/config.yml \
+  .github/ISSUE_TEMPLATE/issue.yml
+```
+
+**T7. Update CLAUDE.md**
+
+Apply the substitution table from the migration design spec
+(Section 2). All substitutions are mechanical text replacements:
+
+```bash
+sed -i '' \
+  -e 's|https://github.com/wphillipmoore/standards-and-conventions|https://github.com/vergil-project/vergil-tooling|g' \
+  -e 's|standard-tooling\.toml|vergil.toml|g' \
+  -e 's|/standard-tooling:memory-init|/vergil:memory-init|g' \
+  -e 's|/standard-tooling:memory-audit|/vergil:memory-audit|g' \
+  -e 's|standard-tooling/docs/specs/worktree-convention\.md|vergil-tooling/docs/specs/worktree-convention.md|g' \
+  -e 's|https://github.com/wphillipmoore/standard-tooling/blob/develop/|https://github.com/vergil-project/vergil-tooling/blob/develop/|g' \
+  -e 's|The canonical text lives in `standard-tooling`|The canonical text lives in `vergil-tooling`|g' \
+  -e 's|\.\./standard-tooling/scripts/lib/git-hooks|../vergil-tooling/scripts/lib/git-hooks|g' \
+  -e 's|st-docker-run -- st-validate|vrg-docker-run -- vrg-validate|g' \
+  -e 's|st-docker-run|vrg-docker-run|g' \
+  -e 's|st-validate|vrg-validate|g' \
+  -e 's|st-commit|vrg-commit|g' \
+  -e 's|ST_COMMIT_CONTEXT|VRG_COMMIT_CONTEXT|g' \
+  -e 's|Standard-tooling CLI tools|VERGIL CLI tools|g' \
+  -e 's|https://github.com/wphillipmoore/mq-rest-admin-dev-environment|https://github.com/mq-rest-admin-project/mq-rest-admin-dev-environment|g' \
+  -e 's|wphillipmoore/standards-and-conventions|vergil-project/vergil-tooling|g' \
+  CLAUDE.md
+```
+
+**Manual review required** after sed — verify that substitutions
+did not corrupt any context-sensitive references. In particular,
+check that the worktree paths and agent prompt contract are intact.
+
+**T8. Update repo-specific files**
+
+Per-repo delta (see Tasks 4–10 below). Skip for repos with no
+additional files.
+
+**T9. Final reference sweep**
+
+```bash
+grep -rn "wphillipmoore\|standard-tooling\|standard-actions\|st-commit\|st-validate\|st-docker\|ST_COMMIT\|standard-tooling:" \
+  --include="*.py" --include="*.md" --include="*.toml" \
+  --include="*.yml" --include="*.yaml" --include="*.json" \
+  --include="*.sh" --include="*.go" --include="*.rs" \
+  --include="*.rb" --include="*.java" --include="*.xml" \
+  --include="*.gradle" --include="*.kts" . \
+  | grep -v CHANGELOG.md | grep -v .git/
+```
+
+Expected: zero matches outside of historical files. Fix any
+remaining references.
+
+**T10. Validate**
+
+Run the repo-specific validation command if one exists:
+
+```bash
+vrg-docker-run -- vrg-validate
+```
+
+If `vrg-docker-run` is not yet available, use repo-specific commands
+(test suite, linting, etc.).
+
+**T11. Commit and push**
+
+Stage all changes. Commit with logically grouped commits:
+
+1. Config rename and update (vergil.toml)
+2. CI/CD workflow updates
+3. Documentation updates (CLAUDE.md, issue templates)
+4. Repo-specific file updates (if any)
+5. Any fixes from validation
+
+Push and open PR:
+
+```bash
+git push -u origin feature/<issue>-org-migration
+
+gh pr create \
+  --repo mq-rest-admin-project/<repo> \
+  --title "chore: migrate to mq-rest-admin-project org and vergil tooling" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Migrate from wphillipmoore to mq-rest-admin-project org and adopt
+post-VERGIL tooling names.
+
+- Config: standard-tooling.toml → vergil.toml (vergil v2.0)
+- CI: wphillipmoore/standard-actions@v1.5 → vergil-project/vergil-actions@v2.0
+- Co-authors: consolidated to single agent entry
+- Documentation: all references updated
+
+## Test plan
+
+- [ ] CI passes on PR
+- [ ] No remaining references to wphillipmoore or standard-tooling
+- [ ] Validation passes
+
+Closes #<issue>
+EOF
+)"
+```
+
+---
+
+## Task 4: Migrate mq-rest-admin-common
+
+**Delta:** None — template only. This is a docs-and-data repo with no
+language-specific metadata.
+
+- [ ] **Step 1: Execute template steps T1–T11**
+
+  No repo-specific files to update (T8 is a no-op).
+
+---
+
+## Task 5: Migrate mq-rest-admin-python
+
+**Delta:** `pyproject.toml` URL updates.
+
+- [ ] **Step 1: Execute template steps T1–T7**
+
+- [ ] **Step 2: Update pyproject.toml (T8)**
+
+  Update the `[project.urls]` section:
+
+  ```toml
+  [project.urls]
+  Homepage = "https://github.com/mq-rest-admin-project/mq-rest-admin-python"
+  Repository = "https://github.com/mq-rest-admin-project/mq-rest-admin-python"
+  Issues = "https://github.com/mq-rest-admin-project/mq-rest-admin-python/issues"
+  ```
+
+- [ ] **Step 3: Grep Python source for old references**
+
+  ```bash
+  grep -rn "wphillipmoore" src/ --include="*.py"
+  ```
+
+  Fix any matches found.
+
+- [ ] **Step 4: Execute template steps T9–T11**
+
+---
+
+## Task 6: Migrate mq-rest-admin-java
+
+**Delta:** `pom.xml` URL updates.
+
+- [ ] **Step 1: Execute template steps T1–T7**
+
+- [ ] **Step 2: Update pom.xml (T8)**
+
+  Update SCM, project URL, and issue management sections:
+
+  ```bash
+  sed -i '' \
+    's|wphillipmoore/mq-rest-admin-java|mq-rest-admin-project/mq-rest-admin-java|g' \
+    pom.xml
+  ```
+
+  Verify the changes cover:
+  - `<url>` (project URL)
+  - `<scm><url>` and `<scm><connection>` and `<scm><developerConnection>`
+  - `<issueManagement><url>` (if present)
+
+- [ ] **Step 3: Check Maven coordinates**
+
+  ```bash
+  grep -n "groupId\|artifactId" pom.xml | head -10
+  ```
+
+  If `groupId` references `wphillipmoore`, update it. If no versions
+  have been published to a public Maven repository, no
+  deprecation/retraction is needed.
+
+- [ ] **Step 4: Grep Java source for old references**
+
+  ```bash
+  grep -rn "wphillipmoore" src/ --include="*.java"
+  ```
+
+  Fix any matches found.
+
+- [ ] **Step 5: Execute template steps T9–T11**
+
+---
+
+## Task 7: Migrate mq-rest-admin-go
+
+**Delta:** `go.mod` module path and internal import updates.
+
+- [ ] **Step 1: Execute template steps T1–T7**
+
+- [ ] **Step 2: Update go.mod module path (T8)**
+
+  ```bash
+  sed -i '' \
+    's|github.com/wphillipmoore/mq-rest-admin-go|github.com/mq-rest-admin-project/mq-rest-admin-go|g' \
+    go.mod
+  ```
+
+- [ ] **Step 3: Update internal Go imports**
+
+  ```bash
+  find . -name '*.go' -exec sed -i '' \
+    's|github.com/wphillipmoore/mq-rest-admin-go|github.com/mq-rest-admin-project/mq-rest-admin-go|g' \
+    {} +
+  ```
+
+- [ ] **Step 4: Check Go module proxy status**
+
+  ```bash
+  curl -s "https://proxy.golang.org/github.com/wphillipmoore/mq-rest-admin-go/@v/list"
+  ```
+
+  If versions have been published, add a `retract` directive for all
+  published versions in the old module's `go.mod` before proceeding.
+  If no versions are published (empty response), skip retraction.
+
+- [ ] **Step 5: Verify Go module integrity**
+
+  ```bash
+  go mod tidy
+  go build ./...
+  ```
+
+- [ ] **Step 6: Execute template steps T9–T11**
+
+---
+
+## Task 8: Migrate mq-rest-admin-ruby
+
+**Delta:** Gemspec URL updates.
+
+- [ ] **Step 1: Execute template steps T1–T7**
+
+- [ ] **Step 2: Update gemspec (T8)**
+
+  Find the gemspec file and update URLs:
+
+  ```bash
+  sed -i '' \
+    's|wphillipmoore/mq-rest-admin-ruby|mq-rest-admin-project/mq-rest-admin-ruby|g' \
+    *.gemspec
+  ```
+
+  Verify the changes cover:
+  - `spec.homepage`
+  - `spec.metadata["source_code_uri"]`
+  - `spec.metadata["changelog_uri"]` (if present)
+  - `spec.metadata["bug_tracker_uri"]` (if present)
+
+- [ ] **Step 3: Grep Ruby source for old references**
+
+  ```bash
+  grep -rn "wphillipmoore" lib/ --include="*.rb"
+  ```
+
+  Fix any matches found.
+
+- [ ] **Step 4: Execute template steps T9–T11**
+
+---
+
+## Task 9: Migrate mq-rest-admin-rust
+
+**Delta:** `Cargo.toml` URL updates.
+
+- [ ] **Step 1: Execute template steps T1–T7**
+
+- [ ] **Step 2: Update Cargo.toml (T8)**
+
+  ```bash
+  sed -i '' \
+    's|wphillipmoore/mq-rest-admin-rust|mq-rest-admin-project/mq-rest-admin-rust|g' \
+    Cargo.toml
+  ```
+
+  Verify the changes cover:
+  - `repository`
+  - `homepage` (if present)
+  - `documentation` (if present)
+
+- [ ] **Step 3: Grep Rust source for old references**
+
+  ```bash
+  grep -rn "wphillipmoore" src/ --include="*.rs"
+  ```
+
+  Fix any matches found.
+
+- [ ] **Step 4: Execute template steps T9–T11**
+
+---
+
+## Task 10: Migrate mq-rest-admin-dev-environment
+
+**Delta:** Reusable action internal references.
+
+- [ ] **Step 1: Execute template steps T1–T7**
+
+- [ ] **Step 2: Check reusable action for org references (T8)**
+
+  ```bash
+  grep -rn "wphillipmoore" .github/actions/ --include="*.yml"
+  ```
+
+  Update any matches to `mq-rest-admin-project`.
+
+- [ ] **Step 3: Check Docker Compose and scripts for org references**
+
+  ```bash
+  grep -rn "wphillipmoore" docker-compose*.yml scripts/ \
+    --include="*.yml" --include="*.yaml" --include="*.sh" 2>/dev/null
+  ```
+
+  Fix any matches found.
+
+- [ ] **Step 4: Execute template steps T9–T11**
+
+---
+
+## Task 11: Cross-Repo Reference Sweep
+
+- [ ] **Step 1: Search for stale references across wphillipmoore repos**
+
+  ```bash
+  gh search code "mq-rest-admin" --owner wphillipmoore \
+    --json repository,path \
+    --jq '.[] | "\(.repository.fullName): \(.path)"'
+  ```
+
+  Any remaining references to `wphillipmoore/mq-rest-admin-*` in
+  other repos should be updated.
+
+- [ ] **Step 2: Search for stale references in vergil-project**
+
+  ```bash
+  gh search code "wphillipmoore/mq-rest-admin" --owner vergil-project \
+    --json repository,path \
+    --jq '.[] | "\(.repository.fullName): \(.path)"'
+  ```
+
+- [ ] **Step 3: Search for stale references in diogenes-project**
+
+  ```bash
+  gh search code "wphillipmoore/mq-rest-admin" --owner diogenes-project \
+    --json repository,path \
+    --jq '.[] | "\(.repository.fullName): \(.path)"'
+  ```
+
+- [ ] **Step 4: Update any cross-references found**
+
+  For each stale reference, open a PR in the affected repo or note
+  it for a future cleanup pass.
+
+---
+
+## Task 12: Local Cleanup
+
+- [ ] **Step 1: Verify all local remotes point to new org**
+
+  ```bash
+  for repo in mq-rest-admin-common mq-rest-admin-python mq-rest-admin-java \
+    mq-rest-admin-go mq-rest-admin-ruby mq-rest-admin-rust \
+    mq-rest-admin-dev-environment; do
+    cd ~/dev/github/$repo
+    echo "$repo: $(git remote get-url origin)"
+    cd -
+  done
+  ```
+
+  All should show `git@github.com:mq-rest-admin-project/<repo>.git`.
+
+- [ ] **Step 2: Clean up worktrees**
+
+  ```bash
+  for repo in mq-rest-admin-common mq-rest-admin-python mq-rest-admin-java \
+    mq-rest-admin-go mq-rest-admin-ruby mq-rest-admin-rust \
+    mq-rest-admin-dev-environment; do
+    cd ~/dev/github/$repo
+    git worktree prune
+    rm -rf .worktrees/ 2>/dev/null
+    cd -
+  done
+  ```
+
+- [ ] **Step 3: Migrate Claude Code memory**
+
+  The memory directory slug is derived from the CWD path. If local
+  directories are not renamed, the slug remains the same and no
+  migration is needed. If directories are renamed, move relevant
+  memories:
+
+  ```
+  Old: ~/.claude/projects/-Users-pmoore-dev-github-mq-rest-admin-<repo>/memory/
+  New: (same if directories unchanged)
+  ```
+
+- [ ] **Step 4: Smoke test end-to-end**
+
+  For each repo, verify basic operations work:
+
+  ```bash
+  for repo in mq-rest-admin-common mq-rest-admin-python mq-rest-admin-java \
+    mq-rest-admin-go mq-rest-admin-ruby mq-rest-admin-rust \
+    mq-rest-admin-dev-environment; do
+    cd ~/dev/github/$repo
+    echo "=== $repo ==="
+    git fetch origin
+    git log --oneline -1
+    cd -
+  done
+  ```
+
+- [ ] **Step 5: Record completion**
+
+  The migration is complete. All repos are at
+  `mq-rest-admin-project/*`, using VERGIL tooling, with org
+  governance active.

--- a/docs/plans/2026-05-14-mq-rest-admin-migration.md
+++ b/docs/plans/2026-05-14-mq-rest-admin-migration.md
@@ -271,6 +271,40 @@ sed -i '' \
   .github/workflows/ci.yml .github/workflows/cd.yml
 ```
 
+**T5a. Replace `secrets: inherit` with explicit secrets in CD workflow**
+
+`secrets: inherit` does not work cross-org. Replace it with explicit
+secret passing in `.github/workflows/cd.yml`:
+
+```yaml
+# Before:
+    secrets: inherit
+
+# After:
+    secrets:
+      APP_CLIENT_ID: ${{ secrets.APP_CLIENT_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+```
+
+**T5b. Configure repository secrets**
+
+Each repo needs `APP_CLIENT_ID` and `APP_PRIVATE_KEY` as repository
+secrets (the App client ID was recorded during governance setup
+Task 2 Step 3; the private key is in Keychain):
+
+```bash
+APP_CLIENT_ID="<client-id-from-governance-setup>"
+APP_PRIVATE_KEY=$(security find-generic-password -s "mq-rest-admin/app-private-key" -w)
+
+gh secret set APP_CLIENT_ID --repo mq-rest-admin-project/<repo> --body "$APP_CLIENT_ID"
+gh secret set APP_PRIVATE_KEY --repo mq-rest-admin-project/<repo> --body "$APP_PRIVATE_KEY"
+```
+
+Verify:
+```bash
+gh secret list --repo mq-rest-admin-project/<repo>
+```
+
 **T6. Update issue templates**
 
 ```bash
@@ -318,7 +352,7 @@ additional files.
 **T9. Final reference sweep**
 
 ```bash
-grep -rn "wphillipmoore\|standard-tooling\|standard-actions\|st-commit\|st-validate\|st-docker\|ST_COMMIT\|standard-tooling:" \
+grep -rn "wphillipmoore\|standard-tooling\|standard-actions\|st-commit\|st-validate\|st-docker\|ST_COMMIT\|standard-tooling:\|secrets:.*inherit" \
   --include="*.py" --include="*.md" --include="*.toml" \
   --include="*.yml" --include="*.yaml" --include="*.json" \
   --include="*.sh" --include="*.go" --include="*.rs" \
@@ -601,7 +635,47 @@ language-specific metadata.
 
 ---
 
-## Task 11: Cross-Repo Reference Sweep
+## Task 11: Verify Module Identity for Go and Java
+
+After per-repo migrations are complete, verify that the module
+identity changes for Go and Java are clean before the first release.
+
+- [ ] **Step 1: Check Go module proxy for old path**
+
+  ```bash
+  curl -s "https://proxy.golang.org/github.com/wphillipmoore/mq-rest-admin-go/@v/list"
+  ```
+
+  If any versions are listed, confirm retraction was handled in
+  Task 7. If empty, no action needed.
+
+- [ ] **Step 2: Check Maven Central for old Java coordinates**
+
+  Verify whether any versions of the Java library have been published
+  under the old `groupId`. If so, confirm deprecation was handled in
+  Task 6.
+
+- [ ] **Step 3: Verify new Go module resolves**
+
+  ```bash
+  GONOSUMCHECK=* go list -m github.com/mq-rest-admin-project/mq-rest-admin-go@latest 2>&1
+  ```
+
+  This will fail until the first version is published under the new
+  path — that's expected. The purpose is to confirm the module path
+  is syntactically valid and the proxy is reachable.
+
+- [ ] **Step 4: Document in release notes template**
+
+  For both Go and Java, ensure the first post-migration release notes
+  include:
+  - The module/artifact identity change
+  - Retraction/deprecation of old identities (if any were published)
+  - Instructions for consumers to update import paths
+
+---
+
+## Task 12: Cross-Repo Reference Sweep
 
 - [ ] **Step 1: Search for stale references across wphillipmoore repos**
 
@@ -637,7 +711,7 @@ language-specific metadata.
 
 ---
 
-## Task 12: Local Cleanup
+## Task 13: Local Cleanup
 
 - [ ] **Step 1: Verify all local remotes point to new org**
 

--- a/docs/plans/2026-05-14-mq-rest-admin-org-governance-setup.md
+++ b/docs/plans/2026-05-14-mq-rest-admin-org-governance-setup.md
@@ -1,0 +1,634 @@
+# MQ REST Admin Org Governance Setup — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps
+> use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Configure the `mq-rest-admin-project` GitHub org with the same
+governance model as `vergil-project` and `diogenes-project` (identity
+separation, branch protection, credential management, GitHub App) so
+that the MQ REST Admin migration (separate plan) can proceed into a
+properly configured org.
+
+**Architecture:** Two-phase approach — pre-transfer infrastructure
+setup (org settings, GitHub App) and post-transfer governance activation
+(credentials, rulesets, agent invitation). Fine-grained PATs and
+rulesets require repos to exist under the resource owner, so they must
+wait until after the transfer.
+
+**Spec:** `docs/specs/2026-05-14-mq-rest-admin-org-governance-design.md`
+
+**Relationship to migration plan:** This is Plan A (org setup). The
+migration plan (`docs/plans/2026-05-14-mq-rest-admin-migration.md`) is
+Plan B. Plan A Phase 1 must complete before Plan B begins. Plan A
+Phase 2 executes after Plan B Task 2 (transfer sequence) completes.
+
+**Prerequisites:**
+- VERGIL rename complete
+- `wphillipmoore-agent` GitHub account exists (created during VERGIL
+  setup)
+
+---
+
+## Phase 1: Pre-Transfer Setup
+
+These tasks are performed once, mostly via the GitHub web UI and `gh`
+CLI. They establish the org configuration that the transfer depends on.
+
+### Task 1: Verify Org Exists and Configure Security Settings
+
+**Files:** None (`gh` CLI)
+
+The `mq-rest-admin-project` org must exist before proceeding. This
+task verifies it and applies security settings.
+
+- [ ] **Step 1: Verify org exists**
+
+  ```bash
+  gh api orgs/mq-rest-admin-project --jq '.login'
+  ```
+
+  Expected: `mq-rest-admin-project`
+
+  If the org does not exist, create it via the GitHub web UI at
+  <https://github.com/organizations/plan>.
+
+- [ ] **Step 2: Require 2FA for all org members**
+
+  ```bash
+  gh api orgs/mq-rest-admin-project \
+    -X PATCH \
+    -f two_factor_requirement_enabled=true
+  ```
+
+- [ ] **Step 3: Set default repository permission to Write**
+
+  ```bash
+  gh api orgs/mq-rest-admin-project \
+    -X PATCH \
+    -f default_repository_permission=write
+  ```
+
+- [ ] **Step 4: Disable forking of private repos**
+
+  ```bash
+  gh api orgs/mq-rest-admin-project \
+    -X PATCH \
+    -F members_can_fork_private_repositories=false
+  ```
+
+- [ ] **Step 5: Verify settings**
+
+  ```bash
+  gh api orgs/mq-rest-admin-project \
+    --jq '{two_factor: .two_factor_requirement_enabled, default_perm: .default_repository_permission, fork_private: .members_can_fork_private_repositories}'
+  ```
+
+  Expected:
+  ```json
+  {
+    "two_factor": true,
+    "default_perm": "write",
+    "fork_private": false
+  }
+  ```
+
+### Task 2: Register `mq-rest-admin-release` GitHub App
+
+**Files:** None (GitHub web UI + Keychain)
+
+- [ ] **Step 1: Register the App**
+
+  Go to <https://github.com/organizations/mq-rest-admin-project/settings/apps/new>
+
+  - App name: `mq-rest-admin-release`
+  - Homepage URL: `https://github.com/mq-rest-admin-project`
+  - Webhook: uncheck "Active" (not needed)
+  - Permissions:
+    - Repository permissions:
+      - Contents: Read and write
+      - Pull requests: Read and write
+      - Metadata: Read-only
+    - No organization permissions
+    - No account permissions
+  - Where can this app be installed: Only on this account
+
+- [ ] **Step 2: Generate a private key**
+
+  On the App settings page, under "Private keys", click
+  "Generate a private key". Download the `.pem` file.
+
+- [ ] **Step 3: Record the App client ID**
+
+  Note the client ID from the App settings page. This is not a
+  secret — it will be recorded in the CI/CD workflow files as an
+  argument to the reusable release workflow.
+
+- [ ] **Step 4: Store the App private key in Keychain**
+
+  ```bash
+  security add-generic-password \
+    -a "mq-rest-admin" \
+    -s "mq-rest-admin/app-private-key" \
+    -w "$(cat /path/to/downloaded-key.pem)" \
+    -T "" \
+    -U
+  ```
+
+- [ ] **Step 5: Verify Keychain retrieval**
+
+  ```bash
+  security find-generic-password -s "mq-rest-admin/app-private-key" -w > /dev/null \
+    && echo "app-private-key: OK"
+  ```
+
+- [ ] **Step 6: Delete the downloaded `.pem` file**
+
+  ```bash
+  rm /path/to/downloaded-key.pem
+  ```
+
+  The key is now stored in the Keychain only.
+
+### Task 3: Pre-Transfer Gate
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Verify all Phase 1 tasks are complete**
+
+  ```bash
+  # Org exists and configured
+  gh api orgs/mq-rest-admin-project \
+    --jq '{two_factor: .two_factor_requirement_enabled, default_perm: .default_repository_permission}'
+
+  # App private key in Keychain
+  security find-generic-password -s "mq-rest-admin/app-private-key" -w > /dev/null \
+    && echo "app-private-key: OK"
+  ```
+
+- [ ] **Step 2: Record completion**
+
+  Phase 1 is complete. Plan B (the migration) can now proceed with
+  the transfer sequence (Task 2). Plan A Phase 2 resumes after all
+  repos are transferred.
+
+---
+
+## Phase 2: Post-Transfer Governance Activation
+
+These tasks execute after Plan B Task 2 (transfer sequence) is
+complete and all 8 repos are at `mq-rest-admin-project/*`.
+
+### Task 4: Generate and Store Human PAT
+
+**Files:** None (GitHub web UI + Keychain)
+
+- [ ] **Step 1: Generate the human PAT**
+
+  Go to <https://github.com/settings/personal-access-tokens/new>
+  (logged in as `wphillipmoore`).
+
+  - Token name: `mq-rest-admin-human`
+  - Expiration: 1 year
+  - Resource owner: `mq-rest-admin-project`
+  - Repository access: All repositories
+  - Permissions:
+    - Administration: Read and write
+    - Contents: Read and write
+    - Issues: Read and write
+    - Pull requests: Read and write
+    - Actions: Read and write
+    - Metadata: Read (auto-granted)
+
+  Copy the token value.
+
+- [ ] **Step 2: Verify PAT scope is correct**
+
+  ```bash
+  GH_TOKEN=<human-pat> gh api user --jq '.login'
+  ```
+
+  Expected: `wphillipmoore`
+
+- [ ] **Step 3: Store the human PAT in Keychain**
+
+  ```bash
+  security add-generic-password \
+    -a "mq-rest-admin" \
+    -s "mq-rest-admin/human-pat" \
+    -w "<paste-human-pat-here>" \
+    -T "" \
+    -U
+  ```
+
+- [ ] **Step 4: Verify Keychain retrieval**
+
+  ```bash
+  security find-generic-password -s "mq-rest-admin/human-pat" -w
+  ```
+
+### Task 5: Install GitHub App and Invite Agent Account
+
+**Files:** None (`gh` CLI + GitHub web UI)
+
+- [ ] **Step 1: Install the App on the org**
+
+  Go to the App settings page → "Install App" → Install on
+  `mq-rest-admin-project` → All repositories.
+
+- [ ] **Step 2: Verify the installation**
+
+  ```bash
+  gh api orgs/mq-rest-admin-project/installations --jq '.[].app_slug'
+  ```
+
+  Expected: `mq-rest-admin-release`
+
+- [ ] **Step 3: List all repos in the org**
+
+  ```bash
+  gh repo list mq-rest-admin-project --json name --jq '.[].name'
+  ```
+
+- [ ] **Step 4: Invite `wphillipmoore-agent` as outside collaborator**
+
+  ```bash
+  for repo in $(gh repo list mq-rest-admin-project --json name --jq '.[].name'); do
+    gh api repos/mq-rest-admin-project/$repo/collaborators/wphillipmoore-agent \
+      -X PUT \
+      -f permission=push
+  done
+  ```
+
+- [ ] **Step 5: Accept the invitation**
+
+  Log in as `wphillipmoore-agent` in the GitHub web UI and accept
+  the collaboration invitation.
+
+- [ ] **Step 6: Verify access**
+
+  Confirm the org's repos are visible at
+  `https://github.com/orgs/mq-rest-admin-project/repositories`.
+
+### Task 6: Generate and Store Agent PAT
+
+**Files:** None (GitHub web UI + Keychain)
+
+- [ ] **Step 1: Generate the agent PAT**
+
+  Go to <https://github.com/settings/personal-access-tokens/new>
+  (logged in as `wphillipmoore-agent`).
+
+  - Token name: `mq-rest-admin-agent`
+  - Expiration: 1 year
+  - Resource owner: `mq-rest-admin-project`
+  - Repository access: All repositories
+  - Permissions:
+    - Contents: Read and write
+    - Issues: Read and write
+    - Pull requests: Read and write
+    - Metadata: Read (auto-granted)
+  - **Not granted:** Administration, Actions, org settings, secrets,
+    deployments
+
+  Copy the token value.
+
+- [ ] **Step 2: Verify agent PAT identity**
+
+  ```bash
+  GH_TOKEN=<agent-pat> gh api user --jq '.login'
+  ```
+
+  Expected: `wphillipmoore-agent`
+
+- [ ] **Step 3: Store the agent PAT in Keychain**
+
+  ```bash
+  security add-generic-password \
+    -a "mq-rest-admin" \
+    -s "mq-rest-admin/agent-pat" \
+    -w "<paste-agent-pat-here>" \
+    -T "" \
+    -U
+  ```
+
+- [ ] **Step 4: Verify Keychain retrieval**
+
+  ```bash
+  security find-generic-password -s "mq-rest-admin/agent-pat" -w
+  ```
+
+### Task 7: Configure Org-Level Rulesets
+
+**Files:** None (`gh` CLI)
+
+- [ ] **Step 1: Create the branch protection ruleset for `develop`**
+
+  ```bash
+  gh api orgs/mq-rest-admin-project/rulesets \
+    -X POST \
+    --input - <<'JSON'
+  {
+    "name": "Branch protection (develop)",
+    "target": "branch",
+    "enforcement": "active",
+    "conditions": {
+      "ref_name": {
+        "include": ["refs/heads/develop"],
+        "exclude": []
+      }
+    },
+    "rules": [
+      { "type": "pull_request",
+        "parameters": {
+          "required_approving_review_count": 1,
+          "dismiss_stale_reviews_on_push": true,
+          "require_code_owner_review": false,
+          "require_last_push_approval": true,
+          "required_review_thread_resolution": true
+        }
+      },
+      { "type": "required_status_checks",
+        "parameters": {
+          "strict_status_checks_policy": true,
+          "status_checks": []
+        }
+      },
+      { "type": "deletion" },
+      { "type": "non_fast_forward" }
+    ],
+    "bypass_actors": []
+  }
+  JSON
+  ```
+
+  **Note:** `bypass_actors: []` means no one can bypass — not even
+  org owners. `status_checks` is empty at the org level because CI
+  check names vary by repo.
+
+- [ ] **Step 2: Create the branch protection ruleset for `main`**
+
+  ```bash
+  gh api orgs/mq-rest-admin-project/rulesets \
+    -X POST \
+    --input - <<'JSON'
+  {
+    "name": "Branch protection (main)",
+    "target": "branch",
+    "enforcement": "active",
+    "conditions": {
+      "ref_name": {
+        "include": ["refs/heads/main"],
+        "exclude": []
+      }
+    },
+    "rules": [
+      { "type": "pull_request",
+        "parameters": {
+          "required_approving_review_count": 1,
+          "dismiss_stale_reviews_on_push": true,
+          "require_code_owner_review": false,
+          "require_last_push_approval": true,
+          "required_review_thread_resolution": true
+        }
+      },
+      { "type": "required_status_checks",
+        "parameters": {
+          "strict_status_checks_policy": true,
+          "status_checks": []
+        }
+      },
+      { "type": "deletion" },
+      { "type": "non_fast_forward" }
+    ],
+    "bypass_actors": []
+  }
+  JSON
+  ```
+
+- [ ] **Step 3: Verify rulesets are active**
+
+  ```bash
+  gh api orgs/mq-rest-admin-project/rulesets \
+    --jq '.[] | {name: .name, enforcement: .enforcement}'
+  ```
+
+  Expected:
+  ```json
+  {"name": "Branch protection (develop)", "enforcement": "active"}
+  {"name": "Branch protection (main)", "enforcement": "active"}
+  ```
+
+### Task 8: Test Rulesets
+
+**Files:** None (manual verification)
+
+- [ ] **Step 1: Verify direct push is blocked**
+
+  Attempt to push directly to `develop` on any repo:
+
+  ```bash
+  cd /tmp && git clone git@github.com:mq-rest-admin-project/mq-rest-admin-common.git mq-test
+  cd mq-test
+  git checkout develop
+  echo "test" > test-rulesets.txt
+  git add test-rulesets.txt
+  git commit -m "test: verify branch protection"
+  git push origin develop
+  ```
+
+  Expected: push rejected with a message about branch protection.
+
+- [ ] **Step 2: Verify PR without review is blocked**
+
+  ```bash
+  git checkout -b test/verify-rulesets
+  git push -u origin test/verify-rulesets
+
+  GH_TOKEN=$(security find-generic-password -s "mq-rest-admin/agent-pat" -w) \
+    gh pr create \
+      --repo mq-rest-admin-project/mq-rest-admin-common \
+      --title "test: verify branch protection" \
+      --body "Testing governance rulesets. Will delete." \
+      --head test/verify-rulesets \
+      --base develop
+
+  # Attempt to merge without approval — should fail
+  GH_TOKEN=$(security find-generic-password -s "mq-rest-admin/agent-pat" -w) \
+    gh pr merge <PR-NUMBER> \
+      --repo mq-rest-admin-project/mq-rest-admin-common \
+      --merge
+  ```
+
+  Expected: merge rejected — required reviews not satisfied.
+
+- [ ] **Step 3: Verify human approval enables merge**
+
+  ```bash
+  # Approve as human
+  GH_TOKEN=$(security find-generic-password -s "mq-rest-admin/human-pat" -w) \
+    gh pr review <PR-NUMBER> \
+      --repo mq-rest-admin-project/mq-rest-admin-common \
+      --approve
+
+  # Merge as human
+  GH_TOKEN=$(security find-generic-password -s "mq-rest-admin/human-pat" -w) \
+    gh pr merge <PR-NUMBER> \
+      --repo mq-rest-admin-project/mq-rest-admin-common \
+      --merge
+  ```
+
+  Expected: merge succeeds.
+
+- [ ] **Step 4: Clean up test branch**
+
+  ```bash
+  gh api repos/mq-rest-admin-project/mq-rest-admin-common/git/refs/heads/test/verify-rulesets \
+    -X DELETE
+  ```
+
+- [ ] **Step 5: Clean up test clone**
+
+  ```bash
+  rm -rf /tmp/mq-test
+  ```
+
+### Task 9: Create Deferred Work Issues
+
+**Files:** None (`gh` CLI)
+
+Create issues in `mq-rest-admin-project/mq-rest-admin-common` for
+deferred governance work.
+
+- [ ] **Step 1: Create issue for `.github` profile repo**
+
+  ```bash
+  gh issue create --repo mq-rest-admin-project/mq-rest-admin-common \
+    --title "feat: set up mq-rest-admin-project/.github profile repo" \
+    --body "Create the mq-rest-admin-project/.github repository for org-level configuration (org README, default community health files, CONTRIBUTING.md, issue/PR templates). Mirrors the same setup planned for vergil-project and diogenes-project."
+  ```
+
+- [ ] **Step 2: Create issue for Claude Code permission model**
+
+  ```bash
+  gh issue create --repo mq-rest-admin-project/mq-rest-admin-common \
+    --title "feat: design Claude Code permission model for mq-rest-admin-project" \
+    --body "Define the minimal set of allowed operations for AI agent sessions, moving away from permissive mode. Coordinate with the same effort in vergil-project and diogenes-project for consistency."
+  ```
+
+- [ ] **Step 3: Create issue for credential audit tooling**
+
+  ```bash
+  gh issue create --repo mq-rest-admin-project/mq-rest-admin-common \
+    --title "feat: extend credential audit tooling for mq-rest-admin-project" \
+    --body "Extend VERGIL's vrg-credential-audit (once built) to cover the mq-rest-admin/ credential namespace in macOS Keychain. Track alongside the same effort in vergil-project and diogenes-project."
+  ```
+
+- [ ] **Step 4: Create issue for merge queue**
+
+  ```bash
+  gh issue create --repo mq-rest-admin-project/mq-rest-admin-common \
+    --title "feat: enable merge queue for mq-rest-admin-project" \
+    --body "Enable GitHub merge queue for the mq-rest-admin-project org when the org moves to a paid GitHub plan. Coordinate with the same effort in vergil-project and diogenes-project."
+  ```
+
+- [ ] **Step 5: Verify issues are created**
+
+  ```bash
+  gh issue list --repo mq-rest-admin-project/mq-rest-admin-common \
+    --json number,title \
+    --jq '.[] | "\(.number): \(.title)"'
+  ```
+
+### Task 10: End-to-End Verification
+
+**Files:** None (manual verification)
+
+- [ ] **Step 1: Verify identity separation**
+
+  ```bash
+  # Agent can push a branch
+  cd /tmp && git clone git@github.com:mq-rest-admin-project/mq-rest-admin-common.git mq-verify
+  cd mq-verify
+  git checkout -b test/verify-identity
+  echo "test" > test-identity.txt
+  git add test-identity.txt
+  git commit -m "test: identity verification"
+  GH_TOKEN=$(security find-generic-password -s "mq-rest-admin/agent-pat" -w) \
+    git push -u origin test/verify-identity
+
+  # Agent cannot merge without approval
+  GH_TOKEN=$(security find-generic-password -s "mq-rest-admin/agent-pat" -w) \
+    gh pr create \
+      --repo mq-rest-admin-project/mq-rest-admin-common \
+      --title "test: identity verification" \
+      --body "Verifying governance model." \
+      --head test/verify-identity \
+      --base develop
+
+  GH_TOKEN=$(security find-generic-password -s "mq-rest-admin/agent-pat" -w) \
+    gh pr merge <PR> --merge
+  # Expected: FAIL — review required
+
+  # Human approves and merges
+  GH_TOKEN=$(security find-generic-password -s "mq-rest-admin/human-pat" -w) \
+    gh pr review <PR> --approve
+  GH_TOKEN=$(security find-generic-password -s "mq-rest-admin/human-pat" -w) \
+    gh pr merge <PR> --merge
+  # Expected: SUCCESS
+  ```
+
+- [ ] **Step 2: Verify credential isolation**
+
+  ```bash
+  # Agent PAT cannot administer
+  GH_TOKEN=$(security find-generic-password -s "mq-rest-admin/agent-pat" -w) \
+    gh api orgs/mq-rest-admin-project \
+      -X PATCH \
+      -f description="test"
+  # Expected: 403 Forbidden
+
+  # Human PAT can administer
+  GH_TOKEN=$(security find-generic-password -s "mq-rest-admin/human-pat" -w) \
+    gh api orgs/mq-rest-admin-project \
+      -X PATCH \
+      -f description="MQ REST Admin — multi-language client libraries for the IBM MQ administrative REST API"
+  # Expected: 200 OK
+  ```
+
+- [ ] **Step 3: Verify GitHub App**
+
+  ```bash
+  GH_TOKEN=$(security find-generic-password -s "mq-rest-admin/human-pat" -w) \
+    gh api orgs/mq-rest-admin-project/installations \
+      --jq '.[].app_slug'
+  # Expected: mq-rest-admin-release
+  ```
+
+- [ ] **Step 4: Verify all credentials in Keychain**
+
+  ```bash
+  security find-generic-password -s "mq-rest-admin/human-pat" -w > /dev/null \
+    && echo "human-pat: OK"
+  security find-generic-password -s "mq-rest-admin/agent-pat" -w > /dev/null \
+    && echo "agent-pat: OK"
+  security find-generic-password -s "mq-rest-admin/app-private-key" -w > /dev/null \
+    && echo "app-private-key: OK"
+  ```
+
+- [ ] **Step 5: Clean up test branches and PRs**
+
+  Remove any test branches and close any test PRs created during
+  verification.
+
+  ```bash
+  gh api repos/mq-rest-admin-project/mq-rest-admin-common/git/refs/heads/test/verify-identity \
+    -X DELETE
+  rm -rf /tmp/mq-verify
+  ```
+
+- [ ] **Step 6: Record completion**
+
+  The org governance setup is complete. The migration is verified
+  and the org is ready for production use.

--- a/docs/plans/2026-05-14-mq-rest-admin-org-governance-setup.md
+++ b/docs/plans/2026-05-14-mq-rest-admin-org-governance-setup.md
@@ -499,25 +499,10 @@ complete and all 8 repos are at `mq-rest-admin-project/*`.
 **Files:** None (`gh` CLI)
 
 Create issues in `mq-rest-admin-project/mq-rest-admin-common` for
-deferred governance work.
+deferred governance work. Issues for `.github` profile repo and
+cross-human review CI check already exist — do not duplicate.
 
-- [ ] **Step 1: Create issue for `.github` profile repo**
-
-  ```bash
-  gh issue create --repo mq-rest-admin-project/mq-rest-admin-common \
-    --title "feat: set up mq-rest-admin-project/.github profile repo" \
-    --body "Create the mq-rest-admin-project/.github repository for org-level configuration (org README, default community health files, CONTRIBUTING.md, issue/PR templates). Mirrors the same setup planned for vergil-project and diogenes-project."
-  ```
-
-- [ ] **Step 2: Create issue for Claude Code permission model**
-
-  ```bash
-  gh issue create --repo mq-rest-admin-project/mq-rest-admin-common \
-    --title "feat: design Claude Code permission model for mq-rest-admin-project" \
-    --body "Define the minimal set of allowed operations for AI agent sessions, moving away from permissive mode. Coordinate with the same effort in vergil-project and diogenes-project for consistency."
-  ```
-
-- [ ] **Step 3: Create issue for credential audit tooling**
+- [ ] **Step 1: Create issue for credential audit tooling**
 
   ```bash
   gh issue create --repo mq-rest-admin-project/mq-rest-admin-common \
@@ -525,7 +510,7 @@ deferred governance work.
     --body "Extend VERGIL's vrg-credential-audit (once built) to cover the mq-rest-admin/ credential namespace in macOS Keychain. Track alongside the same effort in vergil-project and diogenes-project."
   ```
 
-- [ ] **Step 4: Create issue for merge queue**
+- [ ] **Step 2: Create issue for merge queue**
 
   ```bash
   gh issue create --repo mq-rest-admin-project/mq-rest-admin-common \
@@ -533,7 +518,7 @@ deferred governance work.
     --body "Enable GitHub merge queue for the mq-rest-admin-project org when the org moves to a paid GitHub plan. Coordinate with the same effort in vergil-project and diogenes-project."
   ```
 
-- [ ] **Step 5: Verify issues are created**
+- [ ] **Step 3: Verify issues are created**
 
   ```bash
   gh issue list --repo mq-rest-admin-project/mq-rest-admin-common \

--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -36,7 +36,7 @@ submission. Do not construct commit messages or PR bodies manually.
 ### Committing
 
 ```bash
-st-commit \
+vrg-commit \
   --type TYPE --message MESSAGE --agent AGENT \
   [--scope SCOPE] [--body BODY]
 ```
@@ -49,12 +49,12 @@ st-commit \
 - `--body` (optional): detailed commit body
 
 The script resolves the correct `Co-Authored-By` identity from
-`standard-tooling.toml` and the git hooks validate the result.
+`vergil.toml` and the git hooks validate the result.
 
 ### Submitting PRs
 
 ```bash
-st-submit-pr \
+vrg-submit-pr \
   --issue NUMBER --summary TEXT \
   [--linkage KEYWORD] [--title TEXT] \
   [--notes TEXT] [--dry-run]

--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -27,8 +27,8 @@ mq-rest-admin project family.
 
 ## Language implementations
 
-- [mq-rest-admin-java](https://wphillipmoore.github.io/mq-rest-admin-java/1.1/) — Java
-- [mq-rest-admin-python](https://wphillipmoore.github.io/mq-rest-admin-python/1.1/) — Python
-- [mq-rest-admin-go](https://wphillipmoore.github.io/mq-rest-admin-go/1.1/) — Go
-- [mq-rest-admin-ruby](https://github.com/wphillipmoore/mq-rest-admin-ruby) — Ruby (Work in Progress)
-- [mq-rest-admin-rust](https://github.com/wphillipmoore/mq-rest-admin-rust) — Rust (Work in Progress)
+- [mq-rest-admin-java](https://mq-rest-admin-project.github.io/mq-rest-admin-java/1.1/) — Java
+- [mq-rest-admin-python](https://mq-rest-admin-project.github.io/mq-rest-admin-python/1.1/) — Python
+- [mq-rest-admin-go](https://mq-rest-admin-project.github.io/mq-rest-admin-go/1.1/) — Go
+- [mq-rest-admin-ruby](https://github.com/mq-rest-admin-project/mq-rest-admin-ruby) — Ruby (Work in Progress)
+- [mq-rest-admin-rust](https://github.com/mq-rest-admin-project/mq-rest-admin-rust) — Rust (Work in Progress)

--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -27,8 +27,14 @@ mq-rest-admin project family.
 
 ## Language implementations
 
-- [mq-rest-admin-java](https://mq-rest-admin-project.github.io/mq-rest-admin-java/1.1/) — Java
-- [mq-rest-admin-python](https://mq-rest-admin-project.github.io/mq-rest-admin-python/1.1/) — Python
-- [mq-rest-admin-go](https://mq-rest-admin-project.github.io/mq-rest-admin-go/1.1/) — Go
-- [mq-rest-admin-ruby](https://github.com/mq-rest-admin-project/mq-rest-admin-ruby) — Ruby (Work in Progress)
-- [mq-rest-admin-rust](https://github.com/mq-rest-admin-project/mq-rest-admin-rust) — Rust (Work in Progress)
+- [mq-rest-admin-java][java] — Java
+- [mq-rest-admin-python][python] — Python
+- [mq-rest-admin-go][go-docs] — Go
+- [mq-rest-admin-ruby][ruby] — Ruby (Work in Progress)
+- [mq-rest-admin-rust][rust] — Rust (Work in Progress)
+
+[java]: https://mq-rest-admin-project.github.io/mq-rest-admin-java/1.1/
+[python]: https://mq-rest-admin-project.github.io/mq-rest-admin-python/1.1/
+[go-docs]: https://mq-rest-admin-project.github.io/mq-rest-admin-go/1.1/
+[ruby]: https://github.com/mq-rest-admin-project/mq-rest-admin-ruby
+[rust]: https://github.com/mq-rest-admin-project/mq-rest-admin-rust

--- a/docs/site/docs/languages.md
+++ b/docs/site/docs/languages.md
@@ -8,8 +8,8 @@ for its language.
 
 ## Java
 
-**Repository**: [mq-rest-admin-java](https://github.com/wphillipmoore/mq-rest-admin-java)
-| **Documentation**: [wphillipmoore.github.io/mq-rest-admin-java](https://wphillipmoore.github.io/mq-rest-admin-java/1.1/)
+**Repository**: [mq-rest-admin-java](https://github.com/mq-rest-admin-project/mq-rest-admin-java)
+| **Documentation**: [mq-rest-admin-project.github.io/mq-rest-admin-java](https://mq-rest-admin-project.github.io/mq-rest-admin-java/1.1/)
 
 - Maven coordinates: `io.github.wphillipmoore:mq-rest-admin`
 - Zero runtime dependencies beyond Gson
@@ -18,8 +18,8 @@ for its language.
 
 ## Python
 
-**Repository**: [mq-rest-admin-python](https://github.com/wphillipmoore/mq-rest-admin-python)
-| **Documentation**: [wphillipmoore.github.io/mq-rest-admin-python](https://wphillipmoore.github.io/mq-rest-admin-python/1.1/)
+**Repository**: [mq-rest-admin-python](https://github.com/mq-rest-admin-project/mq-rest-admin-python)
+| **Documentation**: [mq-rest-admin-project.github.io/mq-rest-admin-python](https://mq-rest-admin-project.github.io/mq-rest-admin-python/1.1/)
 
 - PyPI package: `pymqrest`
 - `httpx` transport with async support
@@ -27,8 +27,8 @@ for its language.
 
 ## Go
 
-**Repository**: [mq-rest-admin-go](https://github.com/wphillipmoore/mq-rest-admin-go)
-| **Documentation**: [wphillipmoore.github.io/mq-rest-admin-go](https://wphillipmoore.github.io/mq-rest-admin-go/1.1/)
+**Repository**: [mq-rest-admin-go](https://github.com/mq-rest-admin-project/mq-rest-admin-go)
+| **Documentation**: [mq-rest-admin-project.github.io/mq-rest-admin-go](https://mq-rest-admin-project.github.io/mq-rest-admin-go/1.1/)
 
 - Zero external dependencies (Go standard library only)
 - `context.Context` integration for all I/O methods

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -1,9 +1,9 @@
 site_name: mq-rest-admin-common
-site_url: https://wphillipmoore.github.io/mq-rest-admin-common/
+site_url: https://mq-rest-admin-project.github.io/mq-rest-admin-common/
 site_description: >-
   Shared documentation fragments and canonical mapping data
   for the mq-rest-admin project family
-repo_url: https://github.com/wphillipmoore/mq-rest-admin-common
+repo_url: https://github.com/mq-rest-admin-project/mq-rest-admin-common
 repo_name: mq-rest-admin-common
 edit_uri: ""
 

--- a/docs/specs/2026-05-14-mq-rest-admin-migration-design.md
+++ b/docs/specs/2026-05-14-mq-rest-admin-migration-design.md
@@ -16,14 +16,17 @@ are combined into a single migration pass per repo.
 1. **VERGIL rename complete.** All references target post-VERGIL names:
    `vergil-project/vergil-actions`, `vergil.toml`, `vrg-commit`, etc.
 
-2. **`mq-rest-admin-project` org governance complete.** The org exists
-   with security settings, credentials, and GitHub App configured per
-   `docs/specs/2026-05-14-mq-rest-admin-org-governance-design.md`.
+2. **`mq-rest-admin-project` org governance Phase 1 complete.** The org
+   exists with security settings configured and GitHub App registered
+   per governance spec Section 5. Phase 2 (credentials, rulesets,
+   agent invitation) runs after the batch transfer.
 
 ## Scope
 
-This is a multi-repo migration — 7 repositories transferred to the
-same org in a single batch, then updated repo-by-repo. Unlike the
+This is a multi-repo migration — 8 repositories transferred to the
+same org in sequence, then 7 active repos updated repo-by-repo (the
+archived `mq-rest-admin-template` is transferred but not migrated).
+Unlike the
 Diogenes migration (single repo with plugin namespace and directory
 restructuring), these repos have no plugin changes, no renames, and no
 directory restructuring. The changes are limited to org transfer and
@@ -40,12 +43,7 @@ tooling reference updates.
 | `mq-rest-admin-ruby` | Ruby | Language implementation |
 | `mq-rest-admin-rust` | Rust | Language implementation |
 | `mq-rest-admin-dev-environment` | Shell | Docker Compose, reusable GH Action |
-
-### Excluded
-
-| Repository | Reason |
-|---|---|
-| `mq-rest-admin-template` | Archived, no longer active |
+| `mq-rest-admin-template` | None | Archived — transfer only, no per-repo migration |
 
 ### What changes (all repos, uniform)
 
@@ -66,7 +64,7 @@ tooling reference updates.
 |---|---|
 | **common** | None beyond the uniform set |
 | **python** | `pyproject.toml` URLs (Homepage, Repository, Issues) |
-| **java** | Build config URLs (pom.xml or Gradle SCM/URL sections) |
+| **java** | `pom.xml` URLs (SCM, project URL, issue management) |
 | **go** | `go.mod` module path if it references the GitHub org |
 | **ruby** | Gemspec URLs (homepage, source_code_uri, metadata) |
 | **rust** | `Cargo.toml` URLs (repository, homepage) |
@@ -81,26 +79,75 @@ tooling reference updates.
 - Directory structure (no plugin restructuring)
 - Local sibling path references (`../mq-rest-admin-python`, etc.)
 
-## Section 1: Batch Transfer
+## Section 1: Transfer Sequence
 
-All 7 repos are transferred to `mq-rest-admin-project` in a single
-batch via the GitHub API. GitHub creates automatic redirects from the
-old URLs, so CI and cross-references continue working during the
-migration window.
+Repos are transferred one at a time via the GitHub API
+(`POST /repos/{owner}/{repo}/transfer`). There is no atomic batch
+transfer — each call operates independently.
 
-**Pre-flight checks:**
-- No open PRs on any of the 7 repos
-- Clean working state on `develop` for all repos
+### Transfer order
+
+Transfer repos in dependency order so that CI-referenced repos move
+first:
+
+1. `mq-rest-admin-dev-environment` (referenced by language repo CI)
+2. `mq-rest-admin-common` (referenced by language repos for data/docs)
+3. `mq-rest-admin-python`
+4. `mq-rest-admin-java`
+5. `mq-rest-admin-go`
+6. `mq-rest-admin-ruby`
+7. `mq-rest-admin-rust`
+8. `mq-rest-admin-template` (archived — transfer only, no further work)
+
+### Pre-flight checks
+
+- No open PRs on any of the 8 repos
+- Clean working state on `develop` for all active repos
 - All CI passing
+- Governance Phase 1 complete (org exists, security settings
+  configured, GitHub App registered — see governance spec Section 5)
 
-**Post-transfer:**
-- Update local git remotes for all 7 repos
-- Verify all transfers succeeded via GitHub API
+### Transfer procedure
+
+For each repo in order:
+
+1. Transfer via GitHub API
+2. Verify the transfer succeeded:
+   `gh api repos/mq-rest-admin-project/{repo} --jq .full_name`
+3. Update local git remote:
+   `git remote set-url origin git@github.com:mq-rest-admin-project/{repo}.git`
+4. Proceed to the next repo
+
+If a transfer fails, stop. Do not continue transferring remaining
+repos. Diagnose the failure, resolve it, then resume from the failed
+repo.
+
+### Partial failure recovery
+
+If transfers partially complete (some repos moved, some not):
+
+- **Push forward** (preferred): Fix the failure cause and resume
+  transfers from where they stopped. GitHub redirects cover
+  cross-references from already-transferred repos to
+  not-yet-transferred repos.
+- **Roll back**: Transfer already-moved repos back to `wphillipmoore`
+  via the same API. Reset local remotes. This is safe because no
+  per-repo migration branches have been pushed yet at this stage.
+
+### Post-transfer
+
+- Verify all 8 transfers succeeded via GitHub API
+- Run governance Phase 2 (credentials, rulesets, agent invitation —
+  see governance spec Section 5)
 
 ## Section 2: Per-Repo Migration Template
 
 Each repo follows the same task sequence. This is the canonical
 template — repo-specific additions are documented in Section 3.
+
+The migration for each repo should be executed as a tight sequence
+immediately after transfer — do not leave a gap where CI could trigger
+against stale workflow references.
 
 1. **Pre-flight checks** — clean state, on develop, up to date
 2. **Create feature branch** — `feature/<issue-number>-org-migration`
@@ -114,14 +161,32 @@ template — repo-specific additions are documented in Section 3.
    `mq-rest-admin-project/mq-rest-admin-dev-environment/`
 6. **Update issue templates** — source comment references from
    `wphillipmoore/standard-tooling` to `vergil-project/vergil-tooling`
-7. **Update CLAUDE.md** — org references, tooling references, command
-   references (`st-*` to `vrg-*`), standards URL, skills references
+7. **Update CLAUDE.md** — see CLAUDE.md substitution table below
 8. **Update repo-specific files** — per Section 3 delta
 9. **Final reference sweep** — grep for any remaining `wphillipmoore`,
    `standard-tooling`, `standard-actions`, `st-commit`, `st-validate`,
-   `st-docker`, `ST_COMMIT` references
+   `st-docker`, `ST_COMMIT`, `standard-tooling:` references
 10. **Validate** — repo-specific validation command if available
 11. **Push and open PR** — targeting `develop`
+
+### CLAUDE.md substitution table
+
+Step 7 requires the following concrete substitutions:
+
+| Before | After | Location in CLAUDE.md |
+|---|---|---|
+| `https://github.com/wphillipmoore/standards-and-conventions` | `https://github.com/vergil-project/vergil-tooling` | Standards reference header |
+| `standard-tooling.toml` | `vergil.toml` | Repository profile reference |
+| `/standard-tooling:memory-init` | `/vergil:memory-init` | Memory management skills |
+| `/standard-tooling:memory-audit` | `/vergil:memory-audit` | Memory management skills |
+| `standard-tooling/docs/specs/worktree-convention.md` | `vergil-tooling/docs/specs/worktree-convention.md` | Worktree convention link |
+| `https://github.com/wphillipmoore/standard-tooling/blob/develop/` | `https://github.com/vergil-project/vergil-tooling/blob/develop/` | Worktree convention URL |
+| `The canonical text lives in \`standard-tooling\`` | `The canonical text lives in \`vergil-tooling\`` | Worktree section prose |
+| `../standard-tooling/scripts/lib/git-hooks` | `../vergil-tooling/scripts/lib/git-hooks` | Git hooks path |
+| `Standard-tooling CLI tools (\`st-commit\`, \`st-validate\`, etc.)` | `VERGIL CLI tools (\`vrg-commit\`, \`vrg-validate\`, etc.)` | Environment setup |
+| `st-docker-run -- st-validate` | `vrg-docker-run -- vrg-validate` | Validation command |
+| `https://github.com/wphillipmoore/mq-rest-admin-dev-environment` | `https://github.com/mq-rest-admin-project/mq-rest-admin-dev-environment` | Dev environment clone URL |
+| `wphillipmoore/standards-and-conventions` | `vergil-project/vergil-tooling` | Canonical standards reference |
 
 ### Commit strategy
 
@@ -152,10 +217,10 @@ repo with no language-specific metadata.
 ### mq-rest-admin-java
 
 **Additional files:**
-- Build configuration (Maven `pom.xml` or Gradle): Update SCM URLs,
-  project URL, issue management URL to
-  `https://github.com/mq-rest-admin-project/mq-rest-admin-java`
+- `pom.xml` (Maven): Update SCM URLs, project URL, issue management
+  URL to `https://github.com/mq-rest-admin-project/mq-rest-admin-java`
 - Grep `src/` for any `wphillipmoore` references in Java source
+- See Section 3.1 for Maven coordinate and publication implications
 
 ### mq-rest-admin-go
 
@@ -164,6 +229,7 @@ repo with no language-specific metadata.
   `github.com/wphillipmoore/mq-rest-admin-go`, update to
   `github.com/mq-rest-admin-project/mq-rest-admin-go`
 - Grep `*.go` files for any `wphillipmoore` import paths or references
+- See Section 3.1 for Go module path and publication implications
 
 **Note:** A Go module path change is technically a breaking change for
 external consumers. There are no known external consumers of this
@@ -193,12 +259,67 @@ module.
   — those references are updated as part of each language repo's CI
   workflow sweep (the template step covers this)
 
+### Section 3.1: Module Identity Changes (Go and Java)
+
+Go and Java both expose the GitHub org path in their module/package
+identity, unlike Python (where PyPI is the namespace) or Ruby/Rust
+(where the gem/crate name is independent of the source location).
+The org transfer changes how the community discovers and imports
+these libraries.
+
+There are no known external consumers of either module today. This
+makes the migration low-risk but the first post-migration publish
+must handle the identity change cleanly.
+
+#### Go
+
+- **Module path change:** `github.com/wphillipmoore/mq-rest-admin-go`
+  becomes `github.com/mq-rest-admin-project/mq-rest-admin-go`
+- **Internal imports:** All `*.go` files with cross-package imports
+  using the old module path must be updated
+- **Go module proxy:** `proxy.golang.org` caches the old module path
+  permanently — it does not follow redirects. The old path will
+  continue to resolve to the last version published under it.
+- **Retraction:** Add a `retract` directive in the old module's
+  `go.mod` (before transfer) for all published versions, directing
+  users to the new path. If no versions have been published to the
+  proxy, this step can be skipped.
+- **Verification:** `go mod tidy` must succeed after all path updates
+
+#### Java (Maven)
+
+- **Maven coordinates:** If the `groupId` or artifact metadata in
+  `pom.xml` references `wphillipmoore`, update to reflect the new org
+- **Maven Central:** If any versions have been published, the old
+  coordinates remain cached in Maven Central permanently
+- **Deprecation:** Mark old published versions as deprecated in the
+  repository metadata. If no versions have been published to a public
+  repository, this step can be skipped.
+
+#### First post-migration publish checklist
+
+For both Go and Java, the first release after migration should:
+
+1. Verify the new module/artifact identity resolves correctly
+2. Confirm old versions are retracted/deprecated (if any were published)
+3. Document the identity change in release notes
+4. Verify downstream resolution — `go get` / Maven dependency
+   resolution pulls the new identity correctly
+
 ## Section 4: Post-Migration
 
-After all 7 repos are migrated:
+After all 8 repos are transferred and per-repo migrations are
+complete:
 
-1. **Org governance activation** — Plan A Phase 2: invite agent
-   account, configure org-level rulesets, verify governance model
+1. **Governance Phase 2 activation** (if not already done after
+   transfer — see governance spec Section 5):
+   - Create Human PAT and Agent PAT scoped to `mq-rest-admin-project`
+   - Store credentials in Keychain under `mq-rest-admin/` namespace
+   - Install the `mq-rest-admin-release` GitHub App org-wide
+   - Invite `wphillipmoore-agent` as outside collaborator
+   - Configure org-level branch protection rulesets
+   - Verify: agent can push branches, human can approve/merge PRs,
+     direct pushes to `develop`/`main` are blocked, CI runs on PRs
 2. **Create deferred work issues** — `.github` profile repo,
    cross-human review CI check, credential audit tooling, merge queue
 3. **Cross-repo reference sweep** — search all repos in `wphillipmoore`
@@ -210,12 +331,14 @@ After all 7 repos are migrated:
 
 | Risk | Mitigation |
 |---|---|
-| CI breaks during migration window | GitHub redirects cover the gap; sweep all repos promptly |
-| Go module path change breaks external consumers | No known external consumers; document in release notes |
-| Language repos reference dev-environment action at old path | Redirects cover it; each repo's workflow sweep updates the reference |
+| Transfer fails mid-sequence (partial state) | Sequential transfer with verification; stop on failure, push forward or roll back (Section 1) |
+| CI triggers between transfer and workflow update | Tight sequence per repo — push migration branch immediately after transfer to eliminate the window |
+| Go module path change breaks external consumers | No known external consumers; retract old versions if published; document in release notes (Section 3.1) |
+| Java Maven coordinates change | No known external consumers; deprecate old versions if published (Section 3.1) |
+| Language repos reference dev-environment action at old path | Dev-environment transfers first (dependency order); each repo's workflow sweep updates the reference |
 | Credential proliferation (3 more Keychain entries) | Manageable at current scale; credential audit tooling in backlog |
-| 7 repos means 7 PRs to review and merge | Template-driven changes are mechanical and parallelizable |
-| Org-level misconfiguration affects all 7 repos | Verify governance settings before any repo migration begins |
+| 8 repos means 7 PRs to review and merge (template excluded) | Template-driven changes are mechanical and parallelizable |
+| Org-level misconfiguration affects all 8 repos | Verify governance settings before any repo migration begins |
 | Stale cross-references in repos outside this project | Post-migration sweep covers this |
 
 ## File Map (per-repo template)
@@ -233,7 +356,7 @@ After all 7 repos are migrated:
 
 ### Modified (repo-specific, where applicable)
 - `pyproject.toml` (Python)
-- `pom.xml` or Gradle config (Java)
+- `pom.xml` (Java)
 - `go.mod` (Go)
 - Gemspec (Ruby)
 - `Cargo.toml` (Rust)

--- a/docs/specs/2026-05-14-mq-rest-admin-migration-design.md
+++ b/docs/specs/2026-05-14-mq-rest-admin-migration-design.md
@@ -1,0 +1,247 @@
+# MQ REST Admin Migration Design
+
+**Date:** 2026-05-14
+**Status:** Draft
+
+## Problem
+
+The mq-rest-admin repository family (7 repos) needs to move from
+`wphillipmoore` to `mq-rest-admin-project`. The repos also need to
+adopt the post-VERGIL tooling names (`vergil.toml`, `vergil-actions`,
+`vrg-commit`, etc.), which they have not yet picked up. Both changes
+are combined into a single migration pass per repo.
+
+## Prerequisites
+
+1. **VERGIL rename complete.** All references target post-VERGIL names:
+   `vergil-project/vergil-actions`, `vergil.toml`, `vrg-commit`, etc.
+
+2. **`mq-rest-admin-project` org governance complete.** The org exists
+   with security settings, credentials, and GitHub App configured per
+   `docs/specs/2026-05-14-mq-rest-admin-org-governance-design.md`.
+
+## Scope
+
+This is a multi-repo migration — 7 repositories transferred to the
+same org in a single batch, then updated repo-by-repo. Unlike the
+Diogenes migration (single repo with plugin namespace and directory
+restructuring), these repos have no plugin changes, no renames, and no
+directory restructuring. The changes are limited to org transfer and
+tooling reference updates.
+
+### Repositories in scope
+
+| Repository | Primary language | Notes |
+|---|---|---|
+| `mq-rest-admin-common` | None (docs/data) | Hub repo, mapping data, doc fragments |
+| `mq-rest-admin-python` | Python | Language implementation |
+| `mq-rest-admin-java` | Java | Language implementation |
+| `mq-rest-admin-go` | Go | Language implementation |
+| `mq-rest-admin-ruby` | Ruby | Language implementation |
+| `mq-rest-admin-rust` | Rust | Language implementation |
+| `mq-rest-admin-dev-environment` | Shell | Docker Compose, reusable GH Action |
+
+### Excluded
+
+| Repository | Reason |
+|---|---|
+| `mq-rest-admin-template` | Archived, no longer active |
+
+### What changes (all repos, uniform)
+
+| Category | Before | After |
+|---|---|---|
+| GitHub location | `wphillipmoore/mq-rest-admin-*` | `mq-rest-admin-project/mq-rest-admin-*` |
+| Config file | `standard-tooling.toml` | `vergil.toml` |
+| Tooling dependency | `standard-tooling = "v1.4"` | `vergil = "v2.0"` |
+| Co-authors | `claude`, `codex` (per-harness) | `agent` (single entry) |
+| CI workflows | `wphillipmoore/standard-actions@v1.5` | `vergil-project/vergil-actions@v2.0` |
+| Issue templates | `wphillipmoore/standard-tooling` source comments | `vergil-project/vergil-tooling` |
+| CLAUDE.md | `wphillipmoore`, `standard-tooling`, `st-*` | `vergil-project`, `vergil-tooling`, `vrg-*` |
+| Standards reference | `wphillipmoore/standards-and-conventions` | `vergil-project/vergil-tooling` (active docs) |
+
+### What changes (repo-specific)
+
+| Repo | Additional changes |
+|---|---|
+| **common** | None beyond the uniform set |
+| **python** | `pyproject.toml` URLs (Homepage, Repository, Issues) |
+| **java** | Build config URLs (pom.xml or Gradle SCM/URL sections) |
+| **go** | `go.mod` module path if it references the GitHub org |
+| **ruby** | Gemspec URLs (homepage, source_code_uri, metadata) |
+| **rust** | `Cargo.toml` URLs (repository, homepage) |
+| **dev-environment** | Reusable action internal references; language repos' CI references to this action |
+
+### What does NOT change
+
+- Repository names (all keep `mq-rest-admin-*`)
+- Branch names (`develop`, `main`)
+- Internal code logic, tests, mapping data
+- License
+- Directory structure (no plugin restructuring)
+- Local sibling path references (`../mq-rest-admin-python`, etc.)
+
+## Section 1: Batch Transfer
+
+All 7 repos are transferred to `mq-rest-admin-project` in a single
+batch via the GitHub API. GitHub creates automatic redirects from the
+old URLs, so CI and cross-references continue working during the
+migration window.
+
+**Pre-flight checks:**
+- No open PRs on any of the 7 repos
+- Clean working state on `develop` for all repos
+- All CI passing
+
+**Post-transfer:**
+- Update local git remotes for all 7 repos
+- Verify all transfers succeeded via GitHub API
+
+## Section 2: Per-Repo Migration Template
+
+Each repo follows the same task sequence. This is the canonical
+template — repo-specific additions are documented in Section 3.
+
+1. **Pre-flight checks** — clean state, on develop, up to date
+2. **Create feature branch** — `feature/<issue-number>-org-migration`
+3. **Rename config file** — `git mv standard-tooling.toml vergil.toml`
+4. **Update vergil.toml contents** — dependency `vergil = "v2.0"`,
+   co-author consolidated to single `agent` entry
+5. **Update CI/CD workflows** — all `uses:` references from
+   `wphillipmoore/standard-actions@v1.5` to
+   `vergil-project/vergil-actions@v2.0`; also update any references
+   to `wphillipmoore/mq-rest-admin-dev-environment/` to
+   `mq-rest-admin-project/mq-rest-admin-dev-environment/`
+6. **Update issue templates** — source comment references from
+   `wphillipmoore/standard-tooling` to `vergil-project/vergil-tooling`
+7. **Update CLAUDE.md** — org references, tooling references, command
+   references (`st-*` to `vrg-*`), standards URL, skills references
+8. **Update repo-specific files** — per Section 3 delta
+9. **Final reference sweep** — grep for any remaining `wphillipmoore`,
+   `standard-tooling`, `standard-actions`, `st-commit`, `st-validate`,
+   `st-docker`, `ST_COMMIT` references
+10. **Validate** — repo-specific validation command if available
+11. **Push and open PR** — targeting `develop`
+
+### Commit strategy
+
+Each repo's migration is a single feature branch with logically
+grouped commits:
+
+- Config rename and update (vergil.toml)
+- CI/CD workflow updates
+- Documentation updates (CLAUDE.md, issue templates)
+- Repo-specific file updates (if any)
+- Any fixes from validation
+
+## Section 3: Per-Repo Deltas
+
+### mq-rest-admin-common
+
+No additional changes beyond the template. This is a docs-and-data
+repo with no language-specific metadata.
+
+### mq-rest-admin-python
+
+**Additional files:**
+- `pyproject.toml`: Update `[project.urls]` section — Homepage,
+  Repository, Issues URLs to
+  `https://github.com/mq-rest-admin-project/mq-rest-admin-python`
+- Grep `src/` for any `wphillipmoore` references in Python source
+
+### mq-rest-admin-java
+
+**Additional files:**
+- Build configuration (Maven `pom.xml` or Gradle): Update SCM URLs,
+  project URL, issue management URL to
+  `https://github.com/mq-rest-admin-project/mq-rest-admin-java`
+- Grep `src/` for any `wphillipmoore` references in Java source
+
+### mq-rest-admin-go
+
+**Additional files:**
+- `go.mod`: If the module path uses
+  `github.com/wphillipmoore/mq-rest-admin-go`, update to
+  `github.com/mq-rest-admin-project/mq-rest-admin-go`
+- Grep `*.go` files for any `wphillipmoore` import paths or references
+
+**Note:** A Go module path change is technically a breaking change for
+external consumers. There are no known external consumers of this
+module.
+
+### mq-rest-admin-ruby
+
+**Additional files:**
+- Gemspec: Update `homepage`, `source_code_uri`, and metadata URLs to
+  `https://github.com/mq-rest-admin-project/mq-rest-admin-ruby`
+- Grep `lib/` for any `wphillipmoore` references in Ruby source
+
+### mq-rest-admin-rust
+
+**Additional files:**
+- `Cargo.toml`: Update `repository` and `homepage` URLs to
+  `https://github.com/mq-rest-admin-project/mq-rest-admin-rust`
+- Grep `src/` for any `wphillipmoore` references in Rust source
+
+### mq-rest-admin-dev-environment
+
+**Additional files:**
+- `.github/actions/setup-mq/action.yml`: Check for any internal
+  references to `wphillipmoore` org
+- Note: language repos reference this action as
+  `wphillipmoore/mq-rest-admin-dev-environment/.github/actions/setup-mq@main`
+  — those references are updated as part of each language repo's CI
+  workflow sweep (the template step covers this)
+
+## Section 4: Post-Migration
+
+After all 7 repos are migrated:
+
+1. **Org governance activation** — Plan A Phase 2: invite agent
+   account, configure org-level rulesets, verify governance model
+2. **Create deferred work issues** — `.github` profile repo,
+   cross-human review CI check, credential audit tooling, merge queue
+3. **Cross-repo reference sweep** — search all repos in `wphillipmoore`
+   and other orgs for stale references to the old locations
+4. **Local cleanup** — update local directory names if desired, update
+   Claude Code memory paths
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| CI breaks during migration window | GitHub redirects cover the gap; sweep all repos promptly |
+| Go module path change breaks external consumers | No known external consumers; document in release notes |
+| Language repos reference dev-environment action at old path | Redirects cover it; each repo's workflow sweep updates the reference |
+| Credential proliferation (3 more Keychain entries) | Manageable at current scale; credential audit tooling in backlog |
+| 7 repos means 7 PRs to review and merge | Template-driven changes are mechanical and parallelizable |
+| Org-level misconfiguration affects all 7 repos | Verify governance settings before any repo migration begins |
+| Stale cross-references in repos outside this project | Post-migration sweep covers this |
+
+## File Map (per-repo template)
+
+### Renamed
+- `standard-tooling.toml` -> `vergil.toml`
+
+### Modified (all repos)
+- `vergil.toml` (post-rename contents)
+- `.github/workflows/ci.yml`
+- `.github/workflows/cd.yml`
+- `.github/ISSUE_TEMPLATE/config.yml`
+- `.github/ISSUE_TEMPLATE/issue.yml`
+- `CLAUDE.md`
+
+### Modified (repo-specific, where applicable)
+- `pyproject.toml` (Python)
+- `pom.xml` or Gradle config (Java)
+- `go.mod` (Go)
+- Gemspec (Ruby)
+- `Cargo.toml` (Rust)
+- `.github/actions/setup-mq/action.yml` (dev-environment)
+
+### Not modified
+- Source code (no org references in application logic)
+- Tests
+- `mapping-data.json` (common)
+- `CHANGELOG.md` (historical record)
+- License files

--- a/docs/specs/2026-05-14-mq-rest-admin-migration-design.md
+++ b/docs/specs/2026-05-14-mq-rest-admin-migration-design.md
@@ -54,6 +54,7 @@ tooling reference updates.
 | Tooling dependency | `standard-tooling = "v1.4"` | `vergil = "v2.0"` |
 | Co-authors | `claude`, `codex` (per-harness) | `agent` (single entry) |
 | CI workflows | `wphillipmoore/standard-actions@v1.5` | `vergil-project/vergil-actions@v2.0` |
+| CD secrets | `secrets: inherit` | Explicit `secrets:` block (`APP_CLIENT_ID`, `APP_PRIVATE_KEY`) — `secrets: inherit` does not work cross-org |
 | Issue templates | `wphillipmoore/standard-tooling` source comments | `vergil-project/vergil-tooling` |
 | CLAUDE.md | `wphillipmoore`, `standard-tooling`, `st-*` | `vergil-project`, `vergil-tooling`, `vrg-*` |
 | Standards reference | `wphillipmoore/standards-and-conventions` | `vergil-project/vergil-tooling` (active docs) |
@@ -145,9 +146,11 @@ If transfers partially complete (some repos moved, some not):
 Each repo follows the same task sequence. This is the canonical
 template — repo-specific additions are documented in Section 3.
 
-The migration for each repo should be executed as a tight sequence
-immediately after transfer — do not leave a gap where CI could trigger
-against stale workflow references.
+**Note:** In a multi-developer environment, each repo's migration
+should be executed as a tight sequence immediately after transfer to
+prevent CI from triggering against stale workflow references. In a
+single-developer environment where repos are frozen during migration,
+the transfer and per-repo migration phases can be batched separately.
 
 1. **Pre-flight checks** — clean state, on develop, up to date
 2. **Create feature branch** — `feature/<issue-number>-org-migration`
@@ -156,16 +159,20 @@ against stale workflow references.
    co-author consolidated to single `agent` entry
 5. **Update CI/CD workflows** — all `uses:` references from
    `wphillipmoore/standard-actions@v1.5` to
-   `vergil-project/vergil-actions@v2.0`; also update any references
+   `vergil-project/vergil-actions@v2.0`; update any references
    to `wphillipmoore/mq-rest-admin-dev-environment/` to
-   `mq-rest-admin-project/mq-rest-admin-dev-environment/`
+   `mq-rest-admin-project/mq-rest-admin-dev-environment/`; replace
+   `secrets: inherit` in CD workflows with explicit `secrets:` block
+   passing `APP_CLIENT_ID` and `APP_PRIVATE_KEY` (required for
+   cross-org reusable workflow calls)
 6. **Update issue templates** — source comment references from
    `wphillipmoore/standard-tooling` to `vergil-project/vergil-tooling`
 7. **Update CLAUDE.md** — see CLAUDE.md substitution table below
 8. **Update repo-specific files** — per Section 3 delta
 9. **Final reference sweep** — grep for any remaining `wphillipmoore`,
    `standard-tooling`, `standard-actions`, `st-commit`, `st-validate`,
-   `st-docker`, `ST_COMMIT`, `standard-tooling:` references
+   `st-docker`, `ST_COMMIT`, `standard-tooling:`, `secrets: inherit`
+   references
 10. **Validate** — repo-specific validation command if available
 11. **Push and open PR** — targeting `develop`
 
@@ -332,7 +339,7 @@ complete:
 | Risk | Mitigation |
 |---|---|
 | Transfer fails mid-sequence (partial state) | Sequential transfer with verification; stop on failure, push forward or roll back (Section 1) |
-| CI triggers between transfer and workflow update | Tight sequence per repo — push migration branch immediately after transfer to eliminate the window |
+| CI triggers between transfer and workflow update | Repos are frozen during migration (single-developer project); in a multi-developer environment, use a tight transfer-then-update sequence per repo |
 | Go module path change breaks external consumers | No known external consumers; retract old versions if published; document in release notes (Section 3.1) |
 | Java Maven coordinates change | No known external consumers; deprecate old versions if published (Section 3.1) |
 | Language repos reference dev-environment action at old path | Dev-environment transfers first (dependency order); each repo's workflow sweep updates the reference |

--- a/docs/specs/2026-05-14-mq-rest-admin-org-governance-design.md
+++ b/docs/specs/2026-05-14-mq-rest-admin-org-governance-design.md
@@ -127,7 +127,35 @@ Identical to VERGIL:
 - Do not allow forking of private repos
 - Agent accounts are outside collaborators, never org members
 
-## Section 5: What VERGIL Already Handled
+## Section 5: Governance Phasing
+
+Governance setup is split into two phases around the repo transfer:
+
+### Phase 1: Pre-Transfer (before any repos move)
+
+- Create the `mq-rest-admin-project` org
+- Configure org security settings (Section 4)
+- Register the `mq-rest-admin-release` GitHub App (Section 3)
+- Verify org exists and settings are correct
+
+### Phase 2: Post-Transfer (after all repos are in the org)
+
+- Create Human PAT and Agent PAT scoped to `mq-rest-admin-project`
+  (fine-grained PATs require repos to exist under the resource owner)
+- Store credentials in Keychain under `mq-rest-admin/` namespace
+- Install the GitHub App org-wide
+- Invite `wphillipmoore-agent` as outside collaborator
+- Configure org-level branch protection rulesets (Section 2)
+- Verify the full governance model end-to-end
+
+**Why the split:** Fine-grained PATs scoped to `mq-rest-admin-project`
+can only access repos owned by that org. Creating them before the
+transfer means they have no repos to operate on. Rulesets similarly
+need repos to protect. The App registration can happen pre-transfer
+(it's an org-level resource), but installation verification requires
+repos to be present.
+
+## Section 6: What VERGIL Already Handled
 
 The following items from the VERGIL governance plan are prerequisites
 that are already complete by the time this plan executes:
@@ -141,7 +169,7 @@ Consumer-repo co-author config updates (changing `claude`/`codex`
 entries to `agent` in each repo's config) happen during the migration,
 not during governance setup.
 
-## Section 6: Deferred Work
+## Section 7: Deferred Work
 
 These items apply to `mq-rest-admin-project` but are deferred to
 future work. Each item is tracked as a GitHub issue in the org,
@@ -165,3 +193,7 @@ Additionally, with 7 repos in the org (compared to 1 for Diogenes),
 the rulesets and governance settings apply uniformly across all repos.
 This is the desired behavior but means any org-level misconfiguration
 affects all 7 repos simultaneously.
+
+With 8 repos (including the archived `mq-rest-admin-template`), the
+credential and governance surface is slightly larger than initially
+scoped for 7.

--- a/docs/specs/2026-05-14-mq-rest-admin-org-governance-design.md
+++ b/docs/specs/2026-05-14-mq-rest-admin-org-governance-design.md
@@ -67,8 +67,12 @@ in all repos:
 - No deletion of protected branches
 - No non-fast-forward pushes
 
-The `main` branch additionally restricts merge to org owners only
-(release gate).
+The `main` branch uses the same ruleset as `develop`. The release
+gate is credential-based: the release tooling authenticates as the
+GitHub App (`mq-rest-admin-release[bot]`) using the App private key
+stored in the human's Keychain, so the human controls when releases
+happen by controlling the credentials, not by restricting who can
+merge.
 
 ## Section 3: Credential Management
 
@@ -83,11 +87,19 @@ Credentials follow the same pattern as VERGIL and Diogenes but use the
 | Agent PAT | `mq-rest-admin/agent-pat` | Development, AI agent sessions |
 | App private key | `mq-rest-admin/app-private-key` | Release tool (PR creation) |
 
-### Non-Secret Configuration
+### Repository Secrets for CD Workflows
 
-The GitHub App client ID is not a secret. It is recorded directly in
-the CI/CD workflow files as an argument to the reusable release
-workflow. It does not belong in the credential store.
+The CD workflows call reusable release workflows in `vergil-project`.
+Because `secrets: inherit` does not work cross-org, each repo must
+have explicit repository secrets configured:
+
+| Secret | Value | Source |
+|---|---|---|
+| `APP_CLIENT_ID` | GitHub App client ID | App settings page (not a secret, but GitHub Actions requires it in the secrets store for cross-org calls) |
+| `APP_PRIVATE_KEY` | GitHub App private key (PEM) | Keychain `mq-rest-admin/app-private-key` |
+
+These secrets are configured per-repo (not org-level) during the
+per-repo migration phase.
 
 ### Human PAT Scope
 

--- a/docs/specs/2026-05-14-mq-rest-admin-org-governance-design.md
+++ b/docs/specs/2026-05-14-mq-rest-admin-org-governance-design.md
@@ -1,0 +1,167 @@
+# MQ REST Admin Org Governance Design
+
+**Date:** 2026-05-14
+**Status:** Draft
+
+## Problem
+
+The mq-rest-admin repository family (7 repos) is moving from the
+`wphillipmoore` personal GitHub account to the `mq-rest-admin-project`
+GitHub org. The org requires the same governance model established for
+`vergil-project` and `diogenes-project`: identity separation, branch
+protection, credential management, and mechanized automation.
+
+## Relationship to VERGIL Governance
+
+This spec is structurally identical to the VERGIL org governance design
+(`vergil-project/vergil-tooling/docs/specs/2026-05-11-org-governance-design.md`)
+and the Diogenes org governance design
+(`diogenes-project/diogenes/docs/specs/2026-05-13-diogenes-org-governance-design.md`).
+The same foundational principles, identity model, branch protection
+rulesets, credential management patterns, and enforcement model apply.
+Rather than duplicating those specs, this document references them and
+calls out only the MQ REST Admin-specific details.
+
+**Canonical governance spec:**
+`vergil-project/vergil-tooling/docs/specs/2026-05-11-org-governance-design.md`
+
+All sections of the VERGIL governance spec apply to
+`mq-rest-admin-project` unless overridden below.
+
+## Foundational Principles
+
+Same as VERGIL — no changes:
+
+1. AI is a nondeterministic system operating in a space that demands
+   deterministic results.
+2. AI contributions are welcome. Unaccountable AI contributions are not.
+3. The speed limit is human comprehension, not code generation.
+4. Where enforcement can be hard-gated, it must be. Where it cannot,
+   compliance must be audited post-facto.
+
+## Section 1: Identity Model
+
+Identical to VERGIL. Three identity categories:
+
+| Identity | Represents |
+|---|---|
+| `wphillipmoore` | The human |
+| `wphillipmoore-agent` | The human's AI agents |
+| `mq-rest-admin-release[bot]` | Org-level GitHub App for mechanized automation |
+
+The `wphillipmoore-agent` account already exists (created during VERGIL
+setup). No new account is needed — the same agent identity is reused
+across all orgs.
+
+## Section 2: Branch Protection Rulesets
+
+Identical to VERGIL. Org-level rulesets protect `develop` and `main`
+in all repos:
+
+- Require pull request before merging
+- Require at least 1 approving review
+- Require review from someone other than PR author
+- Require status checks to pass
+- Require branches to be up to date before merging
+- No standing bypass permissions
+- No deletion of protected branches
+- No non-fast-forward pushes
+
+The `main` branch additionally restricts merge to org owners only
+(release gate).
+
+## Section 3: Credential Management
+
+### Credentials Stored in Keychain
+
+Credentials follow the same pattern as VERGIL and Diogenes but use the
+`mq-rest-admin/` namespace in the secure credential store:
+
+| Credential | Store entry name | Used by |
+|---|---|---|
+| Human PAT | `mq-rest-admin/human-pat` | Admin, approvals, merges, releases |
+| Agent PAT | `mq-rest-admin/agent-pat` | Development, AI agent sessions |
+| App private key | `mq-rest-admin/app-private-key` | Release tool (PR creation) |
+
+### Non-Secret Configuration
+
+The GitHub App client ID is not a secret. It is recorded directly in
+the CI/CD workflow files as an argument to the reusable release
+workflow. It does not belong in the credential store.
+
+### Human PAT Scope
+
+Fine-grained PAT scoped to `mq-rest-admin-project` as resource owner:
+
+- Repository access: All repositories
+- Permissions: Administration (R/W), Contents (R/W), Issues (R/W),
+  Pull requests (R/W), Actions (R/W), Metadata (Read)
+
+### Agent PAT Scope
+
+Fine-grained PAT scoped to `mq-rest-admin-project` as resource owner:
+
+- Repository access: All repositories
+- Permissions: Contents (R/W), Issues (R/W), Pull requests (R/W),
+  Metadata (Read)
+- Explicitly excluded: Administration, Actions, org settings, secrets,
+  deployments
+
+### GitHub App
+
+A new GitHub App `mq-rest-admin-release` is registered under the
+`mq-rest-admin-project` org (each org gets its own App for isolation).
+Same permissions as `vergil-release` and `diogenes-release`:
+
+- Contents: Read and write
+- Pull requests: Read and write
+- Metadata: Read-only
+- Installed org-wide on `mq-rest-admin-project`
+
+## Section 4: Org Security Settings
+
+Identical to VERGIL:
+
+- Require two-factor authentication for all org members
+- Default repository permission: Write
+- Do not allow forking of private repos
+- Agent accounts are outside collaborators, never org members
+
+## Section 5: What VERGIL Already Handled
+
+The following items from the VERGIL governance plan are prerequisites
+that are already complete by the time this plan executes:
+
+- Removal of `skip_rulesets` escape hatch from standard-tooling
+- Consolidation of co-author config to single `agent` entry in
+  standard-tooling's own config
+- Verification that `vrg-commit` accepts arbitrary agent names
+
+Consumer-repo co-author config updates (changing `claude`/`codex`
+entries to `agent` in each repo's config) happen during the migration,
+not during governance setup.
+
+## Section 6: Deferred Work
+
+These items apply to `mq-rest-admin-project` but are deferred to
+future work. Each item is tracked as a GitHub issue in the org,
+created as part of the migration plan.
+
+1. **`mq-rest-admin-project/.github` profile repo** — org README,
+   default community health files, issue/PR templates
+2. **Cross-human review CI check** — required at 2+ human contributors
+3. **Credential audit tooling** — reuse VERGIL's `vrg-credential-audit`
+   once built; extend to cover `mq-rest-admin/` credential namespace
+4. **Merge queue** — enable when org moves to a paid GitHub plan
+
+## Risks
+
+Same risk profile as VERGIL and Diogenes. The primary additional risk
+is credential proliferation — each new org adds credential entries to
+the Keychain. This is manageable at the current scale but reinforces
+the need for the credential audit tooling tracked in VERGIL's backlog.
+
+Additionally, with 7 repos in the org (compared to 1 for Diogenes),
+the rulesets and governance settings apply uniformly across all repos.
+This is the desired behavior but means any org-level misconfiguration
+affects all 7 repos simultaneously.

--- a/docs/standards-and-conventions.md
+++ b/docs/standards-and-conventions.md
@@ -1,7 +1,7 @@
 # Standards and Conventions
 
 This repository follows the canonical standards at:
-<https://github.com/wphillipmoore/standards-and-conventions>
+<https://github.com/vergil-project/vergil-tooling>
 
 ## Table of Contents
 

--- a/fragments/ai-engineering.md
+++ b/fragments/ai-engineering.md
@@ -150,8 +150,7 @@ Commits that involved AI assistance include a `Co-Authored-By` trailer
 identifying the agent used:
 
 ```text
-Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>
-Co-Authored-By: wphillipmoore-codex <255923655+wphillipmoore-codex@users.noreply.github.com>
+Co-Authored-By: wphillipmoore-agent <284101533+wphillipmoore-agent@users.noreply.github.com>
 ```
 
 This provides a transparent, auditable record of AI involvement in the

--- a/fragments/other-languages.md
+++ b/fragments/other-languages.md
@@ -3,12 +3,12 @@
 The mqrestadmin ecosystem provides the same MQSC-over-REST capability in
 multiple languages. Each implementation shares the mapping tables and test
 suites defined in
-[mq-rest-admin-common](https://github.com/wphillipmoore/mq-rest-admin-common).
+[mq-rest-admin-common](https://github.com/mq-rest-admin-project/mq-rest-admin-common).
 
 | Language | Package | Repository | Documentation |
 |----------|---------|------------|---------------|
-| Python   | pymqrest | [mq-rest-admin-python](https://github.com/wphillipmoore/mq-rest-admin-python) | [Docs](https://wphillipmoore.github.io/mq-rest-admin-python/) |
-| Ruby     | mq-rest-admin | [mq-rest-admin-ruby](https://github.com/wphillipmoore/mq-rest-admin-ruby) | [Docs](https://wphillipmoore.github.io/mq-rest-admin-ruby/) |
-| Java     | mq-rest-admin | [mq-rest-admin-java](https://github.com/wphillipmoore/mq-rest-admin-java) | [Docs](https://wphillipmoore.github.io/mq-rest-admin-java/) |
-| Go       | mqrestadmin | [mq-rest-admin-go](https://github.com/wphillipmoore/mq-rest-admin-go) | [Docs](https://wphillipmoore.github.io/mq-rest-admin-go/) |
-| Rust     | mq-rest-admin | [mq-rest-admin-rust](https://github.com/wphillipmoore/mq-rest-admin-rust) | [Docs](https://wphillipmoore.github.io/mq-rest-admin-rust/) |
+| Python   | pymqrest | [mq-rest-admin-python](https://github.com/mq-rest-admin-project/mq-rest-admin-python) | [Docs](https://mq-rest-admin-project.github.io/mq-rest-admin-python/) |
+| Ruby     | mq-rest-admin | [mq-rest-admin-ruby](https://github.com/mq-rest-admin-project/mq-rest-admin-ruby) | [Docs](https://mq-rest-admin-project.github.io/mq-rest-admin-ruby/) |
+| Java     | mq-rest-admin | [mq-rest-admin-java](https://github.com/mq-rest-admin-project/mq-rest-admin-java) | [Docs](https://mq-rest-admin-project.github.io/mq-rest-admin-java/) |
+| Go       | mqrestadmin | [mq-rest-admin-go](https://github.com/mq-rest-admin-project/mq-rest-admin-go) | [Docs](https://mq-rest-admin-project.github.io/mq-rest-admin-go/) |
+| Rust     | mq-rest-admin | [mq-rest-admin-rust](https://github.com/mq-rest-admin-project/mq-rest-admin-rust) | [Docs](https://mq-rest-admin-project.github.io/mq-rest-admin-rust/) |

--- a/paad/alignment-reviews/2026-05-14-org-migration-alignment.md
+++ b/paad/alignment-reviews/2026-05-14-org-migration-alignment.md
@@ -1,0 +1,108 @@
+# Alignment Review: MQ REST Admin Org Migration
+
+**Date:** 2026-05-14
+**Commit:** 2cd1c7b775c744baa30d63079c50b5c6808ce964
+
+## Documents Reviewed
+
+- **Intent:**
+  - `docs/specs/2026-05-14-mq-rest-admin-org-governance-design.md`
+  - `docs/specs/2026-05-14-mq-rest-admin-migration-design.md`
+- **Action:**
+  - `docs/plans/2026-05-14-mq-rest-admin-org-governance-setup.md`
+  - `docs/plans/2026-05-14-mq-rest-admin-migration.md`
+- **Design:** None (specs serve as both requirements and design)
+
+## Source Control Conflicts
+
+None — no conflicts with recent changes (verified during prior
+pushback review).
+
+## Issues Reviewed
+
+### [1] Plan batches all transfers before per-repo migrations — contradicts spec's tight-sequence requirement
+- **Category:** Design gap
+- **Severity:** Critical
+- **Documents:** Migration spec Section 2 vs. migration plan Tasks 2 + 4–10
+- **Issue:** The spec said "do not leave a gap where CI could trigger
+  against stale workflow references." The plan batches all 8 transfers
+  in Task 2 before any per-repo migrations (Tasks 4–10), creating
+  exactly that gap.
+- **Resolution:** Dropped — single-developer project with repos frozen
+  during migration. No risk of surprise CI triggers. Softened spec
+  language to note this applies in multi-developer environments.
+
+### [2] `main` branch merge restriction to org owners missing from governance plan ruleset
+- **Category:** Missing coverage
+- **Severity:** Important
+- **Documents:** Governance spec Section 2 vs. governance plan Task 7
+- **Issue:** Spec said "restricts merge to org owners only (release
+  gate)." Plan's `main` ruleset was identical to `develop` with no
+  ownership restriction.
+- **Resolution:** Clarified in governance spec that the release gate is
+  credential-based, not ruleset-based. The release tooling authenticates
+  as the GitHub App using the human's Keychain credentials, so the human
+  controls when releases happen. The existing review requirement plus
+  credential isolation is sufficient.
+
+### [3] Deferred work issue mismatch between spec and plan
+- **Category:** Scope compliance
+- **Severity:** Important
+- **Documents:** Governance spec Section 7 vs. governance plan Task 9
+- **Issue:** Plan created issues for "Claude Code permission model"
+  (not in spec, already has its own spec) and ".github profile repo"
+  (already exists). Missing "Cross-human review CI check" from spec
+  (also already exists).
+- **Resolution:** Removed `.github` profile repo and Claude Code
+  permission model steps from plan (both already have existing issues).
+  Kept credential audit tooling and merge queue (don't exist yet).
+
+### [4] Cross-org `secrets: inherit` doesn't work — App credentials not in migration plan
+- **Category:** Missing coverage (new finding during review)
+- **Severity:** Important
+- **Documents:** Governance spec Section 3 + migration spec + migration
+  plan T5 + governance plan
+- **Issue:** `secrets: inherit` in CD workflows only works within the
+  same org. After migration, repos in `mq-rest-admin-project` call
+  reusable workflows in `vergil-project` — cross-org, so explicit
+  secret passing is required. Discovered during Diogenes migration.
+- **Resolution:** Updated all four documents:
+  - Governance spec: added "Repository Secrets for CD Workflows"
+    subsection documenting `APP_CLIENT_ID` and `APP_PRIVATE_KEY` as
+    per-repo secrets
+  - Migration spec: added CD secrets row to "What changes" table,
+    updated template step 5, added `secrets: inherit` to reference sweep
+  - Migration plan: added T5a (replace `secrets: inherit` with explicit
+    block) and T5b (configure repository secrets via `gh secret set`)
+  - Both sweep steps: added `secrets:.*inherit` to grep patterns
+
+### [5] Partial failure recovery options from spec not in migration plan
+- **Category:** Missing coverage
+- **Severity:** Minor
+- **Documents:** Migration spec Section 1 vs. migration plan Task 2
+- **Issue:** Spec documents push-forward and roll-back options; plan
+  says "stop and diagnose" without reproducing recovery options.
+- **Resolution:** Dropped — operator can consult the spec for recovery
+  options if needed.
+
+### [6] First post-migration publish checklist has no plan task
+- **Category:** Missing coverage
+- **Severity:** Minor
+- **Documents:** Migration spec Section 3.1 vs. migration plan
+- **Issue:** Spec's 4-item Go/Java publish checklist had no
+  corresponding plan task.
+- **Resolution:** Added Task 11 (Verify Module Identity for Go and
+  Java) to the migration plan — checks Go module proxy, Maven Central,
+  new path resolution, and release notes template. Renumbered
+  subsequent tasks.
+
+## Unresolved Issues
+
+None — all issues addressed.
+
+## Alignment Summary
+
+- **Requirements:** 28 distinct items across both specs, 27 covered, 1 dropped (tight-sequence — not applicable to single-developer context)
+- **Tasks:** 23 tasks across both plans (governance: 10, migration: 13), 22 in scope, 1 had out-of-scope items removed (governance Task 9)
+- **New coverage added:** 3 items (cross-org secrets, module identity verification, release gate clarification)
+- **Status:** Aligned — ready for implementation

--- a/paad/pushback-reviews/2026-05-14-org-migration-specs-pushback.md
+++ b/paad/pushback-reviews/2026-05-14-org-migration-specs-pushback.md
@@ -1,0 +1,115 @@
+# Pushback Review: MQ REST Admin Org Migration Specs
+
+**Date:** 2026-05-14
+**Specs reviewed:**
+- `docs/specs/2026-05-14-mq-rest-admin-org-governance-design.md`
+- `docs/specs/2026-05-14-mq-rest-admin-migration-design.md`
+**Commit:** 601cf023411ca5ae0b018d817c27bec5e7fb0630
+
+## Source Control Conflicts
+
+None — no conflicts with recent changes. The current codebase state
+(pre-VERGIL tooling names, `wphillipmoore` org references, `claude`/`codex`
+co-author entries) matches what both specs assume.
+
+## Issues Reviewed
+
+### [1] Batch transfer has no atomicity and no rollback plan
+- **Category:** Feasibility + Omissions
+- **Severity:** Critical
+- **Issue:** GitHub's transfer API operates one repo at a time. A mid-batch
+  failure leaves repos split between orgs with no documented recovery.
+- **Resolution:** Replaced "single batch" with explicit sequential transfer
+  procedure including dependency-ordered transfer, per-repo verification,
+  stop-on-failure policy, and rollback instructions.
+
+### [2] CI breaks during migration window
+- **Category:** Feasibility
+- **Severity:** Serious
+- **Issue:** GitHub Actions `uses:` resolution does not reliably follow
+  redirects for transferred repos. Any CI trigger between transfer and
+  workflow file update could fail.
+- **Resolution:** Added requirement for tight transfer-then-update sequence
+  per repo to eliminate the window where stale references could trigger CI.
+
+### [3] CLAUDE.md changes underspecified
+- **Category:** Omissions
+- **Severity:** Serious
+- **Issue:** Step 7 ("Update CLAUDE.md") was too vague — at least 12 distinct
+  reference categories needed updating, including skill names, git hooks
+  path, worktree convention URLs, dev environment URLs, and CLI command names.
+- **Resolution:** Added a concrete before/after substitution table to the
+  per-repo migration template making step 7 mechanically executable.
+
+### [4] "Plan A Phase 2" is an undefined reference
+- **Category:** Ambiguity
+- **Severity:** Serious
+- **Issue:** Post-migration Section 4 referenced "Plan A Phase 2" for
+  governance activation without defining it or pointing to a source.
+- **Resolution:** Replaced with inlined governance activation steps —
+  credential creation, App installation, agent invitation, ruleset
+  configuration, and verification checks.
+
+### [5] Go/Java module identity changes buried as one-liners
+- **Category:** Scope imbalance
+- **Severity:** Moderate
+- **Issue:** Go and Java both expose the GitHub org path in their
+  module/package identity (unlike Python/Ruby/Rust). The org transfer
+  changes how the community discovers and imports these libraries.
+  This was listed as a one-liner alongside trivial URL updates.
+- **Resolution:** Added Section 3.1 covering both languages — Go module
+  proxy caching, retraction directives, Maven coordinate implications,
+  deprecation of old published versions, internal import path updates,
+  and a first-post-migration-publish checklist. Pinned Java to Maven
+  (`pom.xml`) per actual build system.
+
+### [6] No verification step for vergil-actions@v2.0 prerequisite
+- **Category:** Omissions
+- **Severity:** Moderate
+- **Issue:** No concrete check to verify the VERGIL rename prerequisite
+  was met before starting migration.
+- **Resolution:** Dropped — the VERGIL rename is confirmed complete and
+  the `v2.0` tag is published.
+
+### [7] Java build system ambiguous
+- **Category:** Ambiguity
+- **Severity:** Moderate
+- **Issue:** Spec said "Maven pom.xml or Gradle" — should state which
+  build system the repo actually uses.
+- **Resolution:** Pinned to Maven (`pom.xml`) throughout the spec and
+  file map.
+
+### [8] Credential creation timing relative to transfer unspecified
+- **Category:** Omissions
+- **Severity:** Moderate
+- **Issue:** Fine-grained PATs scoped to `mq-rest-admin-project` need
+  repos to exist under that org. The governance spec treated setup as a
+  single "complete before migration" block, but credentials and rulesets
+  can only be created/verified after repos are transferred.
+- **Resolution:** Split governance into Phase 1 (pre-transfer: org
+  creation, security settings, App registration) and Phase 2
+  (post-transfer: credentials, rulesets, agent invitation). Added
+  Section 5 to the governance spec documenting the phasing and rationale.
+  Updated migration spec prerequisites and post-migration steps to
+  reference the phases.
+
+### [9] Archived mq-rest-admin-template left behind in wphillipmoore
+- **Category:** Omissions
+- **Severity:** Minor
+- **Issue:** The archived template repo would remain as an orphan in
+  `wphillipmoore` after the other 7 repos move. GitHub allows
+  transferring archived repos without unarchiving.
+- **Resolution:** Added to the transfer list (8 repos total, transferred
+  archived, no per-repo migration needed). Updated scope, repo count
+  references, and risk table.
+
+## Unresolved Issues
+
+None — all issues addressed.
+
+## Summary
+
+- **Issues found:** 9
+- **Issues resolved:** 8
+- **Dropped:** 1 (finding #6 — prerequisite confirmed met)
+- **Spec status:** Both specs updated and ready for implementation

--- a/vergil.toml
+++ b/vergil.toml
@@ -6,8 +6,7 @@ release-model = "artifact-publishing"
 primary-language = "none"
 
 [project.co-authors]
-claude = "Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>"
-codex = "Co-Authored-By: wphillipmoore-codex <255923655+wphillipmoore-codex@users.noreply.github.com>"
+agent = "Co-Authored-By: wphillipmoore-agent <284101533+wphillipmoore-agent@users.noreply.github.com>"
 
 [ci]
 versions = ["latest"]
@@ -18,4 +17,4 @@ release = true
 docs = true
 
 [dependencies]
-standard-tooling = "v1.4"
+vergil = "v2.0"


### PR DESCRIPTION
## Summary

Migrates mq-rest-admin-common from `wphillipmoore` personal account to `mq-rest-admin-project` organization and adopts vergil tooling, as part of the multi-repo org migration tracked in #195.

- Rename `standard-tooling.toml` to `vergil.toml` with vergil v2.0 dependency
- Update CI/CD workflows to `vergil-project/vergil-actions@v2.0` with explicit secrets
- Update all repo URLs, docs URLs, and GitHub Pages URLs to `mq-rest-admin-project`
- Migrate CLAUDE.md, AGENTS.md, and Claude Code plugin config to vergil equivalents
- Consolidate co-author entries to single `wphillipmoore-agent` identity
- Update CLI references from `st-*` to `vrg-*` commands

## Test plan

- [ ] CI workflows resolve `vergil-project/vergil-actions@v2.0` correctly
- [ ] Documentation site URLs resolve under new org
- [ ] `vergil.toml` is valid and recognized by vergil tooling
- [ ] No remaining references to `wphillipmoore` or `standard-tooling` in active files (historical release notes and plan/spec documents excluded)

Ref #195

🤖 Generated with [Claude Code](https://claude.ai/claude-code)