### PR TITLE
chore(ci): add missing container-tag/container-suffix and fix stale standards doc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
       language: shell
       versions: '["latest"]'
       container-suffix: base
+      container-tag: 'latest'
 
   security:
     uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v2.0
@@ -34,6 +35,8 @@ jobs:
       run-codeql: false
       run-standards: ${{ inputs.run-release != 'false' }}
       run-security: ${{ inputs.run-security != 'false' }}
+      container-suffix: base
+      container-tag: 'latest'
     permissions:
       contents: read
       security-events: write
@@ -43,3 +46,5 @@ jobs:
     with:
       language: shell
       run-release: ${{ inputs.run-release != 'false' }}
+      container-suffix: base
+      container-tag: 'latest'

--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -11,12 +11,12 @@
 - Before modifying any files, check the current branch with `git status -sb`.
 - If on `develop`, create a short-lived `feature/*` branch or ask for explicit approval to proceed on `develop`.
 - If approval is granted to work on `develop`, call it out in the response and proceed only for that user-approved scope.
-- Enable repository git hooks before committing: `git config core.hooksPath scripts/git-hooks`.
+- Enable repository git hooks before committing: `git config core.hooksPath .githooks`.
 
 ## Local validation
 
 ```bash
-markdownlint .            # Lint all Markdown files
+vrg-docker-run -- vrg-validate
 ```
 
 ## Merge strategy override
@@ -37,14 +37,13 @@ submission. Do not construct commit messages or PR bodies manually.
 
 ```bash
 vrg-commit \
-  --type TYPE --message MESSAGE --agent AGENT \
+  --type TYPE --message MESSAGE \
   [--scope SCOPE] [--body BODY]
 ```
 
 - `--type` (required): one of
   `feat|fix|docs|style|refactor|test|chore|ci|build`
 - `--message` (required): commit description
-- `--agent` (required): `claude` or `codex`
 - `--scope` (optional): conventional commit scope
 - `--body` (optional): detailed commit body
 
@@ -62,7 +61,7 @@ vrg-submit-pr \
 
 - `--issue` (required): GitHub issue number (just the number)
 - `--summary` (required): one-line PR summary
-- `--linkage` (optional, default: `Fixes`):
+- `--linkage` (optional, default: `Ref`):
   `Fixes|Closes|Resolves|Ref`
 - `--title` (optional): PR title (default: most recent commit
   subject)


### PR DESCRIPTION
# Pull Request

## Summary

- Add container-tag and container-suffix to reusable workflow jobs; fix stale repository-standards.md

## Issue Linkage

- Ref vergil-project/vergil-tooling#1015

## Notes

- Also addresses vergil-project/vergil-tooling#1013. Changes: add container-tag/container-suffix to quality, security, version jobs in ci.yml; fix hooks path, validation command, --agent flag removal, and --linkage default in repository-standards.md