### PR TITLE
chore(hooks): add Claude Code hook guard, scrub legacy hooksPath refs

### DIFF
--- a/.claude/hooks/guard.sh
+++ b/.claude/hooks/guard.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Claude Code PreToolUse hook shim.
+# Delegates to vrg-hook-guard if available; falls back to a
+# jq-based git/gh check that hard-denies when vergil-tooling
+# is not installed.
+set -euo pipefail
+
+if command -v vrg-hook-guard &>/dev/null; then
+  exec vrg-hook-guard
+fi
+
+input=$(cat)
+command=$(printf '%s' "$input" | jq -r '.tool_input.command // empty')
+bin=$(printf '%s' "$command" | awk '{print $1}')
+base=$(basename "$bin" 2>/dev/null || printf '%s' "$bin")
+
+case "$base" in
+  git|gh)
+    jq -n '{
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: "vergil-tooling is not available. This repository requires a correctly configured environment — all git/gh operations are blocked until resolved."
+      }
+    }'
+    exit 0
+    ;;
+esac
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,22 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(vrg-*)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/guard.sh"
+          }
+        ]
+      }
+    ]
+  },
   "extraKnownMarketplaces": {
     "vergil-marketplace": {
       "source": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,9 +105,9 @@ This is a documentation-only repository. There are no build or test commands.
 
 ### Environment Setup
 
-```bash
-git config core.hooksPath ../vergil-tooling/scripts/lib/git-hooks  # Enable git hooks
-```
+The Claude Code PreToolUse hook guard (`.claude/hooks/guard.sh`)
+blocks raw `git` and `gh` commands — use `vrg-git` / `vrg-gh`
+wrappers.
 
 VERGIL CLI tools (`vrg-commit`, `vrg-validate`, etc.) are
 pre-installed in the dev container images. No local setup required.

--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -11,7 +11,7 @@
 - Before modifying any files, check the current branch with `git status -sb`.
 - If on `develop`, create a short-lived `feature/*` branch or ask for explicit approval to proceed on `develop`.
 - If approval is granted to work on `develop`, call it out in the response and proceed only for that user-approved scope.
-- Enable repository git hooks before committing: `git config core.hooksPath .githooks`.
+- The Claude Code hook guard (`.claude/hooks/guard.sh`) blocks raw `git`/`gh` — use `vrg-git`/`vrg-gh`.
 
 ## Local validation
 

--- a/fragments/development/quality-gates.md
+++ b/fragments/development/quality-gates.md
@@ -6,13 +6,11 @@ and CI pipelines enforce the same standards (plus additional checks) on
 every pull request. Pull requests cannot merge until all required jobs
 pass.
 
-## Git hooks
+## Claude Code hook guard
 
-Git hooks are stored in `scripts/git-hooks/` and activated with:
-
-```bash
-git config core.hooksPath scripts/git-hooks
-```
+The `.claude/hooks/guard.sh` PreToolUse hook blocks raw `git` and
+`gh` commands in AI agent sessions — all operations must go through
+the `vrg-git` / `vrg-gh` wrappers.
 
 ### pre-commit
 


### PR DESCRIPTION
# Pull Request

## Summary

- Add PreToolUse hook guard, update settings.json, scrub legacy core.hooksPath references from docs

## Issue Linkage

- Ref #209

## Notes

- Part of vergil-project/vergil-tooling#1142