### PR TITLE
chore(tooling): migrate to vergil v2.1

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,7 +21,8 @@
     "vergil-marketplace": {
       "source": {
         "source": "github",
-        "repo": "vergil-project/vergil-claude-plugin"
+        "repo": "vergil-project/vergil-claude-plugin",
+        "ref": "v2.1"
       }
     }
   },

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   docs:
-    uses: vergil-project/vergil-actions/.github/workflows/cd-docs.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/cd-docs.yml@v2.1
     with:
       pre-deploy-command: python3 scripts/dev/generate_mapping_docs.py
     permissions:
@@ -22,5 +22,5 @@ jobs:
 
   release:
     if: github.ref == 'refs/heads/main'
-    uses: vergil-project/vergil-actions/.github/workflows/cd-release.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/cd-release.yml@v2.1
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -40,6 +41,7 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      actions: read
 
   version:
     uses: vergil-project/vergil-actions/.github/workflows/ci-version-bump.yml@v2.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   quality:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-quality.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/ci-quality.yml@v2.1
     with:
       language: shell
       versions: '["latest"]'
@@ -29,7 +29,7 @@ jobs:
       container-tag: 'latest'
 
   security:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v2.1
     with:
       language: shell
       run-codeql: false
@@ -42,7 +42,7 @@ jobs:
       security-events: write
 
   version:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-version-bump.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/ci-version-bump.yml@v2.1
     with:
       language: shell
       run-release: ${{ inputs.run-release != 'false' }}

--- a/vergil.toml
+++ b/vergil.toml
@@ -12,4 +12,4 @@ release = true
 docs = true
 
 [dependencies]
-vergil = "v2.0"
+vergil = "v2.1"


### PR DESCRIPTION
# Pull Request

## Summary

- Migrate the repo from vergil v2.0 to v2.1 by bumping the vergil.toml dependency pin, all five vergil-actions reusable-workflow refs, and the Claude plugin marketplace ref to v2.1.

## Issue Linkage

- Ref #214

## Notes

- Scope per issue #214: vergil.toml pin v2.0->v2.1 and 5 workflow @v2.0 refs (ci-quality, ci-security, ci-version-bump, cd-docs, cd-release) ->@v2.1. Also pinned .claude/settings.json marketplace source.ref to v2.1 — the recently-normalized versioned ref that vrg-github-repo-config now audits (was unset). Local vrg-validate green; vrg-github-repo-config audit reports local: compliant. No VERSION bump: VERSION 1.2.2 already leads last release tag v1.2.1; chore commits don't trigger ci-version-bump. The v2.1 moving tag resolves to v2.1.5. Remaining @v2.0 strings in docs/plans and paad reviews are historical records of the prior v1.x->v2.0 migration, intentionally left untouched.